### PR TITLE
RPG basic weighted inventory system

### DIFF
--- a/A game of light and shadows/GLSCore/CharacterInformation.fs
+++ b/A game of light and shadows/GLSCore/CharacterInformation.fs
@@ -1,40 +1,26 @@
 ﻿module GLSCore.CharacterInformation
 
 open GLSCore.GameElement
+open GLSCore.InventoryItems
 
 open System
 
-type CharacterStats = {
-    Health          : LifePoints 
-    Speed           : float 
-    Strength        : float 
-    MagicPower      : float option 
-    Defense         : int
-    Resistance      : int
-    MagicResist     : float  
-    Evade           : int 
-    Luck            : int
-}
-with 
-    member x.applyTemporaryDefense (tPoints: int) = 
-        { x with Defense = x.Defense + tPoints }
-
-type CharacterRole = 
+type CharacterRole =
     | Wizard of MoveRange
     | Knight of MoveRange
     | Fighter of MoveRange
-    | MagicSoldier of MoveRange 
+    | MagicSoldier of MoveRange
     | Sniper  of MoveRange
-with    
-    member x.moveRange = 
-        match x with 
-        | Wizard mr -> mr 
-        | Knight mr -> mr 
-        | Fighter mr -> mr 
-        | MagicSoldier mr -> mr 
+with
+    member x.moveRange =
+        match x with
+        | Wizard mr -> mr
+        | Knight mr -> mr
+        | Fighter mr -> mr
+        | MagicSoldier mr -> mr
         | Sniper  mr -> mr
 
-type CharacterJob = 
+type CharacterJob =
     | Healer        of CharacterRole  * CharacterStats
     | Knight        of CharacterRole  * CharacterStats
     | Berserker     of CharacterRole  * CharacterStats
@@ -43,8 +29,8 @@ type CharacterJob =
     | BowAndBlade   of CharacterRole  * CharacterStats
     | Necromancer   of CharacterRole  * CharacterStats
     | Nightblade    of CharacterRole  * CharacterStats
-with 
-    member x.Stats = 
+with
+    member x.Stats =
         match x with
         | Healer       (_,stats) -> stats
         | Knight       (_,stats) -> stats
@@ -55,7 +41,7 @@ with
         | Necromancer  (_,stats) -> stats
         | Nightblade   (_,stats) -> stats
 
-    member x.Role = 
+    member x.Role =
         match x with
         | Healer       (role, _) -> role
         | Knight       (role, _) -> role
@@ -69,80 +55,80 @@ with
 let doesHaveTacticalAdvantage (fstCharacter: CharacterJob) (sndCharacter: CharacterJob) =
     match fstCharacter.Role, sndCharacter.Role with
     | Wizard _, Fighter _ -> true // 25 % more damage
-    | Wizard _, Sniper _ -> true // 15 % more damage 
+    | Wizard _, Sniper _ -> true // 15 % more damage
     | CharacterRole.Knight _, Wizard _ -> true // 20% more damage
     | Sniper _, Fighter _ -> true // 20% more damage
     | Sniper _, CharacterRole.Knight _ -> true // 5% more damage
-    | MagicSoldier _, CharacterRole.Knight _ -> true // 3 % by sword only 
-    | _, _ -> false 
+    | MagicSoldier _, CharacterRole.Knight _ -> true // 3 % by sword only
+    | _, _ -> false
 
 // Describe how strong a unit is suppose to be
 // Will impact the overall stats
 [<Literal>]
-let lowTiersStatsFactor = 1  
+let lowTiersStatsFactor = 1
 
 [<Literal>]
-let midLowTiersStatsFactor = 1.075  
+let midLowTiersStatsFactor = 1.075
 
 [<Literal>]
-let midTiersStatsFactor = 1.1233 
+let midTiersStatsFactor = 1.1233
 
 [<Literal>]
-let highTiersStatsFactor = 1.1785  
+let highTiersStatsFactor = 1.1785
 
 [<Literal>]
-let heroClassTiersStatsFactor = 1.2375 
+let heroClassTiersStatsFactor = 1.2375
 
-type UnitTiers = 
+type UnitTiers =
     | Low
     | MidLow
     | Mid
     | High
     | HeroClass
 
-
-type CharacterEquipement = {
-    Hat         : string 
-    Gauntlets   : string 
-    Armor       : string 
-    Weapon      : string 
-    Pants       : string 
-    Boots       : string
+type Equipment = {
+    Hat : Hat option
+    Armor : Armor option
+    Legs  : Pants option
+    Hands : Gauntlets option
+    Ring  : Ring option
+    Weapon : Weaponry option
+    Shield : Shield option
 }
 
-type CombatStyle = 
+
+type CombatStyle =
     | DualWielder of int
-    | MaceUser of int 
+    | MaceUser of int
     |  ``Sword and shield`` of int
-    | Archer of int 
+    | Archer of int
     | ``Staff wielder`` of int
     | Polyvalent of int
-with 
-    member x.actionPoints = 
-        match x with 
-        | DualWielder ap -> ap 
+with
+    member x.actionPoints =
+        match x with
+        | DualWielder ap -> ap
         | MaceUser ap -> ap
-        | Archer ap -> ap 
-        | Polyvalent ap -> ap 
-        | ``Sword and shield`` ap -> ap 
-        | ``Staff wielder`` ap -> ap 
-
+        | Archer ap -> ap
+        | Polyvalent ap -> ap
+        | ``Sword and shield`` ap -> ap
+        | ``Staff wielder`` ap -> ap
 
 type CharacterState = {
-    CurrentPos       : Pos 
+    CurrentPos       : Pos
     CurrentDirection : PlayerDirection
 }
 
 [<AbstractClass>]
-type CharacterBase(job: CharacterJob, state: CharacterState) =
+type CharacterBase(job: CharacterJob, state: CharacterState, equipment: Equipment) =
 
     abstract member TeamParty: Object array
 
-    abstract member ActionPoints: int with get, set
+    abstract member ActionPoints: int with get
 
-    abstract member ExperiencePoints: float with get, set
+    abstract member ExperiencePoints: float with get
 
-    abstract member LevelUpPoints: int with get, set
+    abstract member LevelUpPoints: int with get
 
     abstract member MoveRange: MoveRange
 
@@ -154,5 +140,6 @@ type CharacterBase(job: CharacterJob, state: CharacterState) =
 
     member x.Job = job
 
-    member x.Stats = job.Stats 
+    member x.Stats = job.Stats
 
+    member x.Equipment = equipment

--- a/A game of light and shadows/GLSCore/ExperienceSystemManager.fs
+++ b/A game of light and shadows/GLSCore/ExperienceSystemManager.fs
@@ -9,56 +9,56 @@ open GLSCore.PartyCharacter
 
 open GLSManager.Protocol
 
-open Akka 
+open Akka
 open Akka.FSharp
 
 
 
 
 (*
- Determines the action factor which will be combine to 
+ Determines the action factor which will be combine to
  the tactical advantage  and the target's tiers.
  The combination is multiplied by the unit's attributed experience points
-*)    
+*)
 [<Literal>]
 let UnitExperiencePoints = 10.0
 
-let canCharacterLevelUp (pc: PartyCharacter) = 
+let canCharacterLevelUp (pc: PartyCharacter) =
     pc.ExperiencePoints >= 125.00
 
-let attributeLevelUpPoints (pc: PartyCharacter) = 
+let attributeLevelUpPoints (pc: PartyCharacter) =
     let lvlUpPoints =  Math.Floor (pc.ExperiencePoints % 125.00 ) |> int32
     pc.LevelUpPoints <- pc.LevelUpPoints + lvlUpPoints
     pc.ExperiencePoints <- 0.00
-   
 
-let computeExperienceGains (caller: PartyCharacter) (target: PartyCharacter) (action: EngageAction) = 
-    let actionFactor = 
-        match action with 
+
+let computeExperienceGains (caller: PartyCharacter) (target: PartyCharacter) (action: EngageAction) =
+    let actionFactor =
+        match action with
         | AttackedTarget -> 1.10
         | EvadeAttacker -> 0.90
-        | EliminatedTarget -> 1.25 
+        | EliminatedTarget -> 1.25
         | BlockedAttacker  -> 0.75
         | _ -> 0.00
 
 
-    let tacticalAdvantageFactor = 
-        match doesHaveTacticalAdvantage caller.Job target.Job  with 
+    let tacticalAdvantageFactor =
+        match doesHaveTacticalAdvantage caller.Job target.Job  with
         | true -> 0.05
-        | false -> -0.05    
+        | false -> -0.05
 
     let tiersFactor =
         target.Tiers
         |> Option.map(fun t ->
-            match t with 
+            match t with
             | Low -> 1.00
             | MidLow -> 1.05
             | Mid -> 1.08
             | High -> 1.12
             | HeroClass -> 1.35
         )
-    let tiersFactor = 
-        match tiersFactor with 
+    let tiersFactor =
+        match tiersFactor with
         | None -> 1.00
         | Some v -> v
 
@@ -70,16 +70,16 @@ let system = System.create "system" <| Configuration.load ()
 
 let processExperienceGain
     (mailbox: Actor<ExperienceSystemProtocol>) =
-    let rec loop () = actor { 
+    let rec loop () = actor {
         let! message = mailbox.Receive ()
-        match message with 
-        | ComputeGain (c, t, action) -> 
-            let experiencePoints = computeExperienceGains c t action    
+        match message with
+        | ComputeGain (c, t, action) ->
+            let experiencePoints = computeExperienceGains c t action
             if canCharacterLevelUp c then attributeLevelUpPoints c
             // return updated party member to the battle sequence manager
-        
-        return! loop () 
+
+        return! loop ()
     }
     loop ()
 
-let commandManagerRef = spawn system "Experience System" <| processExperienceGain 
+let commandManagerRef = spawn system "Experience System" <| processExperienceGain

--- a/A game of light and shadows/GLSCore/GLSCore.fsproj
+++ b/A game of light and shadows/GLSCore/GLSCore.fsproj
@@ -22,7 +22,7 @@
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <DocumentationFile>bin\Debug\GLSAssetLibrary.XML</DocumentationFile>
+    <DocumentationFile>bin\Debug\GLSCore.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -80,6 +80,32 @@
     <None Include="Simulation.fsx" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="FSharp.Core">
+      <HintPath>..\packages\FSharp.Core.3.1.2.5\lib\net40\FSharp.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FsPickler">
+      <HintPath>..\packages\FsPickler.1.2.21\lib\net45\FsPickler.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="mscorlib" />
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NLog">
+      <HintPath>..\packages\NLog.4.3.2\lib\net45\NLog.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Xml" />
     <Reference Include="Akka">
       <HintPath>..\packages\Akka.1.1.1\lib\net45\Akka.dll</HintPath>
       <Private>True</Private>
@@ -92,10 +118,6 @@
       <HintPath>..\packages\Akka.Logger.NLog.1.1.1\lib\net45\Akka.Logger.NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FSharp.Core">
-      <HintPath>..\packages\FSharp.Core.3.1.2.5\lib\net40\FSharp.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="FSharp.PowerPack">
       <HintPath>..\packages\FSPowerPack.Core.Community.3.0.0.0\lib\Net40\FSharp.PowerPack.dll</HintPath>
       <Private>True</Private>
@@ -104,40 +126,18 @@
       <HintPath>..\packages\FSPowerPack.Linq.Community.3.0.0.0\lib\Net40\FSharp.PowerPack.Linq.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FsPickler">
-      <HintPath>..\packages\FsPickler.1.2.21\lib\net45\FsPickler.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="FsUnit.NUnit">
       <HintPath>..\packages\FsUnit.2.3.1\lib\net45\FsUnit.NUnit.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="mscorlib" />
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NHamcrest">
       <HintPath>..\packages\FsUnit.2.3.1\lib\net45\NHamcrest.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NLog">
-      <HintPath>..\packages\NLog.4.3.2\lib\net45\NLog.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.3.4.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Core" />
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
@@ -146,4 +146,13 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <ProjectExtensions>
+    <MonoDevelop>
+      <Properties>
+        <Policies>
+          <DotNetNamingPolicy DirectoryNamespaceAssociation="PrefixedFlat" ResourceNamePolicy="FileFormatDefault" />
+        </Policies>
+      </Properties>
+    </MonoDevelop>
+  </ProjectExtensions>
 </Project>

--- a/A game of light and shadows/GLSCore/InventoryItems.fs
+++ b/A game of light and shadows/GLSCore/InventoryItems.fs
@@ -1,176 +1,284 @@
-﻿module GLSCore.InventoryItems
+﻿    module GLSCore.InventoryItems
 
-open System 
+    open System 
 
-//Represents unit for weight in kilograms
-[<Measure>] type kg
+    //Represents unit for weight in kilograms
+    [<Measure>] type kg
 
-//Represents unit for currency
-[<Measure>] type usd
+    //Represents unit for currency
+    [<Measure>] type usd
 
-[<AbstractClass>]
-type InventoryItem() =
-
-    abstract member ItemName : string 
-
-    abstract member ItemDescription : string 
-
-    abstract member ItemWeight : float<kg> 
-
-    abstract member ItemPrice : float<usd> 
-
-    abstract member Quantity : int 
-
-type WeaponRank = 
-    | RankE 
-    | RankD
-    | RankC
-    | RankB 
-    | RankA
-    | RankS
-
-type WeaponStat = {
-    Damage : float 
-    Defense : float 
-    Speed : float 
-    Critical : float 
-    HitLimit : int 
-    Rank : WeaponRank
-}
-
-type ConsummableItem = 
-    | HealthPotion      
-    | HighHealthPotion  
-    | MegaHealthPotion  
-    | Elixir            
-    | HighElixir        
-    | MegaElixir        
-    | PhoenixFeather    
-    | MedicinalHerb     
-    | Antidote    
-
-type Dagger = 
-    | RustedDagger of InventoryItem * WeaponStat
-    | IronDagger of InventoryItem  * WeaponStat 
-    | SteelDagger of InventoryItem * WeaponStat
-
-type Sword = 
-    | BrokenSword of InventoryItem * WeaponStat
-    | RustedSword of InventoryItem * WeaponStat
-    | IronSword of InventoryItem * WeaponStat
-    | SteelSword of InventoryItem * WeaponStat
-
-type Axe = 
-    | RustedAxe of InventoryItem * WeaponStat
-    | IronAxe of InventoryItem * WeaponStat
-    | RustedBattleAxe of InventoryItem * WeaponStat
-    | IronBattleAxe of InventoryItem * WeaponStat
-    | StellBattleAxe of InventoryItem * WeaponStat
-
-type Spear =
-    | RustedSpear of InventoryItem  * WeaponStat
-    | IronSpear  of InventoryItem * WeaponStat
-    | SteelSpear of InventoryItem * WeaponStat
-
-type Staff = 
-    | RookieStaff of InventoryItem * WeaponStat
-    | AdeptStaff  of InventoryItem * WeaponStat
-    | SorcererStaff of InventoryItem * WeaponStat
-    | NecromancerStaff of InventoryItem * WeaponStat
-
-type Blade = 
-    | RustedLongBlade of InventoryItem * WeaponStat
-    | RustedKatana of InventoryItem * WeaponStat
-    | IronLongBlade of InventoryItem * WeaponStat
-    | CurvedLongBlade of InventoryItem * WeaponStat
-    | SteelKatana of InventoryItem * WeaponStat
-    | SteelLongBlade of InventoryItem * WeaponStat
-
-type SpellbookStats = {
-    AttackRange : int 
-    Rank        : WeaponRank
-    Uses    : int
-}
-
-type Spellbook =
-    | Fireball of InventoryItem * SpellbookStats
-    | Thunder of InventoryItem * SpellbookStats
-    | Frost of InventoryItem * SpellbookStats
-    | Hellfire of InventoryItem * SpellbookStats
-    | BlackFire of InventoryItem * SpellbookStats
-    | Tornado of InventoryItem * SpellbookStats
-    | WildWind of InventoryItem * SpellbookStats
-    | StormOfBlades of InventoryItem * SpellbookStats
-    | ThorStorm of InventoryItem * SpellbookStats
+    //Max weight of the inventory bag
+    [<Literal>] 
+    let MaxWeight = 100.00<kg>
    
-type Weaponry = 
-    | Dagger of Dagger 
-    | Sword of Sword 
-    | Axe of Axe
-    | Spear of Spear
-    | Staff of Staff 
-    | LongBlade of Blade
-    | Spellbook of Spellbook
+    type WeaponRank = 
+        | RankE 
+        | RankD
+        | RankC
+        | RankB 
+        | RankA
+        | RankS
 
-type Hat = 
-    | SorcererHat of InventoryItem 
-    | InfantryHat of InventoryItem 
-    | JourneyManHelmet of InventoryItem 
-    | RustedHelmet of InventoryItem 
-    | MerlinsHat of InventoryItem 
-    | IronHelmet of InventoryItem 
-    | SteelHelmet of InventoryItem 
+    type WeaponStat = {
+        Damage : float 
+        Defense : float 
+        Speed : float 
+        Critical : float 
+        HitLimit : int 
+        Rank : WeaponRank
+    }
 
-type Armor = 
-    | InfantryArmor of InventoryItem 
-    | RustedArmor of InventoryItem 
-    | IronArmor of InventoryItem
-    | SteelArmor of InventoryItem
-    | MyrtilleArmor of InventoryItem
+    type InventoryItem =
 
-type Pants = 
-    | InfantryPants of InventoryItem
-    | IronPants of InventoryItem
-    | SteelPants of InventoryItem
-    | MyrtillePants of InventoryItem
+        abstract member Quantity : int with get, set
 
-type Gauntlets = 
-    | InfantryGauntless of InventoryItem
-    | RustedGauntless of InventoryItem
-    | IronGauntless of InventoryItem
-    | SteelGauntless of InventoryItem
 
-type Ring = 
-    | ExtraStrenghtRing of InventoryItem
-    | ExtraDamageRing of InventoryItem
-    | ExtraHeathRing  of InventoryItem
-    | ExtraMana        of InventoryItem
+    type ConsummableItem = 
+        | HealthPotion      
+        | HighHealthPotion  
+        | MegaHealthPotion  
+        | Elixir            
+        | HighElixir        
+        | MegaElixir        
+        | PhoenixFeather    
+        | MedicinalHerb     
+        | Antidote   
+    interface InventoryItem 
+    with 
+        override x.ToString() = 
+            match x with 
+            | HealthPotion      -> "Health Potion"
+            | HighHealthPotion  -> "High Health Potion"
+            | MegaHealthPotion  -> "Mega Health Potion"
+            | Elixir            -> "Elixir"
+            | HighElixir        -> "High Elixir"
+            | MegaElixir        -> "Mega Elixir"
+            | PhoenixFeather    -> "Phoenix Feather"
+            | MedicinalHerb     -> "Medicinal Herb"
+            | Antidote          -> "Antidote"
 
-type Shield = 
-    | RustedShield of InventoryItem
-    | SmallShield of InventoryItem
-    | KnightShield of InventoryItem
-    | HeavyShield of InventoryItem
-    | SteelShield of InventoryItem
+        member x.Weight = 
+            match x with 
+            | HealthPotion       -> 0.02<kg>
+            | HighHealthPotion   -> 0.03<kg>
+            | MegaHealthPotion   -> 0.05<kg>
+            | Elixir             -> 0.02<kg>
+            | HighElixir         -> 0.03<kg>
+            | MegaElixir         -> 0.05<kg>
+            | PhoenixFeather     -> 0.05<kg>
+            | MedicinalHerb      -> 0.03<kg>
+            | Antidote           -> 0.10<kg>
 
-type Inventory = {
-    Inventory : InventoryItem array
-}
-with 
-    member x.filterFromLightestToHeaviest() =
-        x.Inventory
-        |> Array.sortBy(fun item -> item.ItemWeight)
+        member x.Price = 
+            match x with 
+            | HealthPotion       -> 100<usd>
+            | HighHealthPotion   -> 150<usd>
+            | MegaHealthPotion   -> 225<usd>
+            | Elixir             -> 125<usd>
+            | HighElixir         -> 175<usd>
+            | MegaElixir         -> 275<usd>
+            | PhoenixFeather     -> 350<usd>
+            | MedicinalHerb      -> 50<usd>
+            | Antidote           -> 125<usd>
 
-    member x.filterFromHeaviestToLightest() = 
-        x.Inventory 
-        |> Array.sortBy (fun x -> -x.ItemWeight - 1.0<kg>) // Sort in a descending order 
+        member x.ItemQuantity = 
+            
 
-type Equipment = {
-    Hat : Hat 
-    Armor : Armor 
-    Legs  : Pants 
-    Hands : Gauntlets 
-    Ring  : Ring 
-    Weapon : Weaponry
-    Shield : Shield option
-}
+
+
+    type Dagger = 
+        | RustedDagger of InventoryItem * WeaponStat
+        | IronDagger of InventoryItem  * WeaponStat 
+        | SteelDagger of InventoryItem * WeaponStat
+
+    type Sword = 
+        | BrokenSword of InventoryItem * WeaponStat
+        | RustedSword of InventoryItem * WeaponStat
+        | IronSword of InventoryItem * WeaponStat
+        | SteelSword of InventoryItem * WeaponStat
+
+    type Axe = 
+        | RustedAxe of InventoryItem * WeaponStat
+        | IronAxe of InventoryItem * WeaponStat
+        | RustedBattleAxe of InventoryItem * WeaponStat
+        | IronBattleAxe of InventoryItem * WeaponStat
+        | StellBattleAxe of InventoryItem * WeaponStat
+
+    type Spear =
+        | RustedSpear of InventoryItem  * WeaponStat
+        | IronSpear  of InventoryItem * WeaponStat
+        | SteelSpear of InventoryItem * WeaponStat
+
+    type Staff = 
+        | RookieStaff of InventoryItem * WeaponStat
+        | AdeptStaff  of InventoryItem * WeaponStat
+        | SorcererStaff of InventoryItem * WeaponStat
+        | NecromancerStaff of InventoryItem * WeaponStat
+
+    type Blade = 
+        | RustedLongBlade of InventoryItem * WeaponStat
+        | RustedKatana of InventoryItem * WeaponStat
+        | IronLongBlade of InventoryItem * WeaponStat
+        | CurvedLongBlade of InventoryItem * WeaponStat
+        | SteelKatana of InventoryItem * WeaponStat
+        | SteelLongBlade of InventoryItem * WeaponStat
+
+    type SpellbookStats = {
+        AttackRange : int 
+        Rank        : WeaponRank
+        Uses    : int
+    }
+
+    type Spellbook =
+        | Fireball of InventoryItem * SpellbookStats
+        | Thunder of InventoryItem * SpellbookStats
+        | Frost of InventoryItem * SpellbookStats
+        | Hellfire of InventoryItem * SpellbookStats
+        | BlackFire of InventoryItem * SpellbookStats
+        | Tornado of InventoryItem * SpellbookStats
+        | WildWind of InventoryItem * SpellbookStats
+        | StormOfBlades of InventoryItem * SpellbookStats
+        | ThorStorm of InventoryItem * SpellbookStats
+   
+    type Weaponry = 
+        | Dagger of Dagger 
+        | Sword of Sword 
+        | Axe of Axe
+        | Spear of Spear
+        | Staff of Staff 
+        | LongBlade of Blade
+        | Spellbook of Spellbook
+
+    type Hat = 
+        | SorcererHat of InventoryItem 
+        | InfantryHat of InventoryItem 
+        | JourneyManHelmet of InventoryItem 
+        | RustedHelmet of InventoryItem 
+        | MerlinsHat of InventoryItem 
+        | IronHelmet of InventoryItem 
+        | SteelHelmet of InventoryItem 
+
+    type Armor = 
+        | InfantryArmor of InventoryItem 
+        | RustedArmor of InventoryItem 
+        | IronArmor of InventoryItem
+        | SteelArmor of InventoryItem
+        | MyrtilleArmor of InventoryItem
+
+    type Pants = 
+        | InfantryPants of InventoryItem
+        | IronPants of InventoryItem
+        | SteelPants of InventoryItem
+        | MyrtillePants of InventoryItem
+
+    type Gauntlets = 
+        | InfantryGauntless of InventoryItem
+        | RustedGauntless of InventoryItem
+        | IronGauntless of InventoryItem
+        | SteelGauntless of InventoryItem
+
+    type Ring = 
+        | ExtraStrenghtRing of InventoryItem
+        | ExtraDamageRing of InventoryItem
+        | ExtraHeathRing  of InventoryItem
+        | ExtraMana        of InventoryItem
+
+    type Shield = 
+        | RustedShield of InventoryItem
+        | SmallShield of InventoryItem
+        | KnightShield of InventoryItem
+        | HeavyShield of InventoryItem
+        | SteelShield of InventoryItem
+
+    let makeBagItemsDistinct (bag: InventoryItem array) = 
+        bag |> Seq.distinct |> Seq.toArray
+
+    type GameItems = 
+        | Consummable   of ConsummableItem
+        | Shield        of Shield 
+        | Ring          of Ring 
+        | Gloves        of Gauntlets 
+        | Legs          of Pants
+        | Armor         of Armor 
+        | Hat           of Hat 
+        | Weapon        of Weaponry
+        | Spells        of Spellbook
+        | LongBlade     of Blade 
+        | MagicStaff    of Staff
+        | LongSpear     of Spear 
+        | Axe           of Axe 
+        | Sword         of Sword
+        | Dagger        of Dagger 
+    with 
+
+    (*
+        abstract member ItemName : string 
+
+        abstract member ItemDescription : string 
+
+        abstract member ItemWeight : float<kg> 
+
+        abstract member ItemPrice : float<usd> 
+
+        abstract member Quantity : int with get, set
+
+    *)
+        member x.Name 
+
+    type Inventory = {
+        Bag : GameItem array
+        Weight: float<kg>
+    }
+    with 
+        member x.filterFromLightestToHeaviest() =
+            x.Bag |> Array.sortBy(fun item -> item.ItemWeight)
+
+        member x.filterFromHeaviestToLightest() = 
+            x.Bag  |> Array.sortBy (fun x -> -x.ItemWeight - 1.0<kg>) // Sort in a descending order
+
+        member x.addItem (ii: InventoryItem): Inventory = 
+            if x.Weight >= MaxWeight <> true then x 
+            elif (x.Weight + ii.ItemWeight) >= MaxWeight then x
+            else 
+                let oItemIndex = x.Bag |> Array.tryFindIndex(fun x -> x = ii)
+                match oItemIndex with 
+                | Some index -> 
+                    // There already an item of this type in the bag
+                    let item = x.Bag |> Array.find(fun x -> x = ii)
+                    let newBag = 
+                        x.Bag
+                        |> Array.filter((<>) item)
+                        |> Array.append 
+                            [| 
+                                { item with Quantity = item.Quantity + ii.Quantity }
+                             |]
+                        |> makeBagItemsDistinct
+
+                    let inventory = { x with Bag = newBag }
+                    { inventory with Weight = inventory.Weight + item.ItemWeight }
+                | None -> 
+                    let newBag = x.Bag |> Array.append [|ii|] |> makeBagItemsDistinct
+                    let inventory = { x with Bag = newBag }
+                    { inventory with Weight = inventory.Weight + ii.ItemWeight }
+
+        member x.addItems (iiArr: InventoryItem array) = 
+            let newBag = x.Bag |> Array.append iiArr |> makeBagItemsDistinct
+            let inventory = { x with Bag = newBag }
+
+            { inventory with Weight = inventory.Weight + 0.0<kg> }
+
+        member x.dropItem (ii:InventoryItem) = 
+            let newBag = x.Bag |> Array.filter( (<>) ii)
+            let inventory = { x with Bag = newBag }
+            { inventory with Weight = inventory.Weight - ii.ItemWeight }
+       
+    type Equipment = {
+        Hat : Hat 
+        Armor : Armor 
+        Legs  : Pants 
+        Hands : Gauntlets 
+        Ring  : Ring 
+        Weapon : Weaponry
+        Shield : Shield option
+    }

--- a/A game of light and shadows/GLSCore/InventoryItems.fs
+++ b/A game of light and shadows/GLSCore/InventoryItems.fs
@@ -1,7 +1,7 @@
 ﻿    module GLSCore.InventoryItems
 
-    open System 
-    open System.Collections 
+    open System
+    open System.Collections
 
     //Represents unit for weight in kilograms
     [<Measure>] type kg
@@ -12,129 +12,127 @@
     // units of measure representing the character and equipment stats
     [<Measure>] type dmg // damage
     [<Measure>] type def // defense
-    [<Measure>] type str // strenght 
+    [<Measure>] type str // strenght
     [<Measure>] type spd // speed
-    [<Measure>] type intel // intelligence 
-    [<Measure>] type res // resistance 
-    [<Measure>] type mgpwr  // magic power 
-    [<Measure>] type mgres // magic resistance 
+    [<Measure>] type intel // intelligence
+    [<Measure>] type res // resistance
+    [<Measure>] type mgpwr  // magic power
+    [<Measure>] type mgres // magic resistance
     [<Measure>] type evd    // evade
     [<Measure>] type lck  // luck
     [<Measure>] type ctr // critical
     [<Measure>] type hl // hit limit
-    [<Measure>] type hp // health points 
-    [<Measure>] type mp // mana points 
+    [<Measure>] type hp // health points
+    [<Measure>] type mp // mana points
     [<Measure>] type eu // equipment usage
 
-    type IStats = 
+    type IStats =
         abstract member showStat : unit -> string
-    
-    type IEnergyPoint =
-        abstract CurrentPoints : float 
-        abstract MaxPoints     : float
-        abstract capPoints : unit -> IEnergyPoint 
-        abstract raisePoints : float -> IEnergyPoint
-        abstract reducePoints : float -> IEnergyPoint 
 
-    type HealthPoint = 
+    type IEnergyPoint =
+        abstract capPoints : unit -> IEnergyPoint
+        abstract raisePoints : float -> IEnergyPoint
+        abstract reducePoints : float -> IEnergyPoint
+
+    type HealthPoint =
         { CurrentLife: float<hp>
           MaxLife : float<hp> }
         interface IEnergyPoint with
             member x.capPoints () =
                 if x.CurrentLife > x.MaxLife then { CurrentLife = x.MaxLife; MaxLife = x.MaxLife } :> IEnergyPoint else x :> IEnergyPoint
 
-            member x.raisePoints (raisePoint:float) = 
+            member x.raisePoints (raisePoint:float) =
                 let lifePoints = raisePoint * 1.0<hp>
                 let raisedHealth = { x with CurrentLife = x.CurrentLife + lifePoints }
                 (raisedHealth :> IEnergyPoint).capPoints()
 
-            member x.reducePoints (hitPoint: float) = 
+            member x.reducePoints (hitPoint: float) =
                 let lifePoints = hitPoint * 1.0<hp>
                 let reducedLife = { x with CurrentLife = x.CurrentLife - lifePoints }
                 (reducedLife :> IEnergyPoint)
-        member x.raiseMaxLife (healthPoints: float<hp>) = 
+        member x.raiseMaxLife (healthPoints: float<hp>) =
             { CurrentLife = x.CurrentLife + healthPoints; MaxLife = x.MaxLife + healthPoints }
-        member x.isCharacterDead() = 
+        member x.isCharacterDead() =
             x.CurrentLife <= 0.0<hp>
 
-    type ManaPoint = 
+    type ManaPoint =
         { CurrentMana: float<mp>
           MaxMana : float<mp> }
         interface IEnergyPoint with
             member x.capPoints () =
                 if x.CurrentMana > x.MaxMana then { ManaPoint.CurrentMana = x.MaxMana; ManaPoint.MaxMana = x.MaxMana } :> IEnergyPoint else x :> IEnergyPoint
 
-            member x.raisePoints (raisePoint:float) = 
+            member x.raisePoints (raisePoint:float) =
                 let manaPoints = raisePoint * 1.0<mp>
                 let raisedHealth = { x with CurrentMana = x.CurrentMana + manaPoints }
                 (raisedHealth :> IEnergyPoint).capPoints()
 
-            member x.reducePoints (reducePoint: float) = 
+            member x.reducePoints (reducePoint: float) =
                 let manaPoints = reducePoint * 1.0<mp>
                 let reducedLife = { x with CurrentMana = x.CurrentMana - manaPoints }
-                (reducedLife :> IEnergyPoint)        
-        member x.canCharacterPerformMagic() =   
+                (reducedLife :> IEnergyPoint)
+        member x.canCharacterPerformMagic() =
              x.CurrentMana > 0.00<mp>
-        member x.capManaAtZero() : ManaPoint = 
-            if x.CurrentMana < 0.00<mp> then 
+        member x.capManaAtZero() : ManaPoint =
+            if x.CurrentMana < 0.00<mp> then
                 { x with CurrentMana = 0.00<mp>}
-            else 
-                x 
-        member x.raiseMaxMana (manaPoints: float<mp>) = 
+            else
+                x
+        member x.raiseMaxMana (manaPoints: float<mp>) =
             { CurrentMana = x.CurrentMana + manaPoints; MaxMana = x.MaxMana + manaPoints }
 
-     type WeaponRank = 
-        | RankE 
+     type WeaponRank =
+        | RankE
         | RankD
         | RankC
-        | RankB 
+        | RankB
         | RankA
         | RankS
 
     type CharacterStats = {
         Health          : HealthPoint
-        Mana            : ManaPoint 
+        Mana            : ManaPoint
         Speed           : float<spd>
         Strength        : float<str>
-        MagicPower      : float<mgpwr> option 
+        MagicPower      : float<mgpwr> option
         Defense         : int<def>
         Resistance      : int<res>
         MagicResist     : float<mgres>
         Evade           : int<evd>
         Luck            : int<lck>
     }
-    with 
-        interface IStats with 
-            member x.showStat() = 
+    with
+        interface IStats with
+            member x.showStat() =
                 sprintf "Max health : %O - Max mana : %O - Strenght : %O - Defense : %O - Magic power : %O - Resistance : %O - Magic resistance : %O - Evade : %O - Luck : %O" x.Health.MaxLife x.Mana.MaxMana x.Strength x.Defense x.MagicPower x.Resistance x.MagicResist x.Evade x.Luck
-        member x.applyTemporaryDefense (tPoints: int<def>) = 
+        member x.applyTemporaryDefense (tPoints: int<def>) =
             { x with Defense = x.Defense + tPoints }
     let removeUnitFromFloat (x: float<_>) =
-        float x 
+        float x
     let removeUnitFromInt (x: int<_>) =
         int x
 
     //Max weight of the inventory bag
-    [<Literal>] 
+    [<Literal>]
     let MaxWeight = 500.00<kg>
 
     [<AutoOpen>]
-    module ConsummableItems = 
-        type ItemVariationProvenance = 
+    module ConsummableItems =
+        type ItemVariationProvenance =
             | FromTheShop
             | FromTheInventory
 
-        type ConsummableItem = 
-            | HealthPotion        
-            | HighHealthPotion   
-            | MegaHealthPotion   
-            | Elixir              
-            | HighElixir          
-            | MegaElixir          
-            | PhoenixFeather      
-            | MedicinalHerb       
-            override x.ToString() = 
-                match x with 
+        type ConsummableItem =
+            | HealthPotion
+            | HighHealthPotion
+            | MegaHealthPotion
+            | Elixir
+            | HighElixir
+            | MegaElixir
+            | PhoenixFeather
+            | MedicinalHerb
+            override x.ToString() =
+                match x with
                 | HealthPotion     -> "Health Potion"
                 | HighHealthPotion  -> "High Health Potion"
                 | MegaHealthPotion -> "Mega Health Potion"
@@ -144,12 +142,12 @@
                 | PhoenixFeather    -> "Phoenix Feather"
                 | MedicinalHerb     -> "Medicinal Herb"
 
-            member x.Name = 
-                match x with 
+            member x.Name =
+                match x with
                 | _ -> x.ToString()
 
-            member x.Weight = 
-                match x with 
+            member x.Weight =
+                match x with
                 | HealthPotion       -> 0.02<kg>
                 | HighHealthPotion   -> 0.03<kg>
                 | MegaHealthPotion   -> 0.05<kg>
@@ -159,8 +157,8 @@
                 | PhoenixFeather     -> 0.05<kg>
                 | MedicinalHerb      -> 0.03<kg>
 
-            member x.Price = 
-                match x with 
+            member x.Price =
+                match x with
                 | HealthPotion       -> 100<usd>
                 | HighHealthPotion   -> 150<usd>
                 | MegaHealthPotion   -> 225<usd>
@@ -170,18 +168,18 @@
                 | PhoenixFeather     -> 350<usd>
                 | MedicinalHerb      -> 50<usd>
 
-            member x.ConsummeItem (characterStat: CharacterStats)= 
-                match x with 
+            member x.ConsummeItem (characterStat: CharacterStats)=
+                match x with
                 | HealthPotion      -> { characterStat with  Health = (characterStat.Health :> IEnergyPoint).raisePoints 15.0:?> HealthPoint }
                 | HighHealthPotion   -> { characterStat with Health = (characterStat.Health :> IEnergyPoint).raisePoints 30.0 :?> HealthPoint }
                 | MegaHealthPotion   -> { characterStat with Health = (characterStat.Health :> IEnergyPoint).raisePoints 50.0 :?> HealthPoint }
                 | Elixir             -> { characterStat with Mana = (characterStat.Health :> IEnergyPoint).raisePoints 10.0 :?> ManaPoint }
                 | HighElixir         -> { characterStat with Mana = (characterStat.Health :> IEnergyPoint).raisePoints 20.0 :?> ManaPoint }
                 | MegaElixir         -> { characterStat with Mana = (characterStat.Health :> IEnergyPoint).raisePoints 30.0 :?> ManaPoint }
-                | PhoenixFeather     -> 
+                | PhoenixFeather     ->
                     if not (characterStat.Health.isCharacterDead()) then characterStat
-                    else 
-                        { characterStat with 
+                    else
+                        { characterStat with
                             Health = (characterStat.Health :> IEnergyPoint).raisePoints ((removeUnitFromFloat characterStat.Health.MaxLife) * 0.50) :?> HealthPoint
                             Mana = (characterStat.Mana :> IEnergyPoint).raisePoints ((removeUnitFromFloat characterStat.Mana.MaxMana) * 0.50) :?> ManaPoint
                         }
@@ -190,96 +188,96 @@
 
 
     [<AutoOpen>]
-    module Weapons = 
+    module Weapons =
         type WeaponStat = {
             Damage : float<dmg>
             Intelligence : float<intel> option
-            Defense : float<def> 
-            Speed : float<spd> 
+            Defense : float<def>
+            Speed : float<spd>
             Critical : float<ctr>
-            HitLimit : int<hl> 
+            HitLimit : int<hl>
             Rank : WeaponRank
         }
-        with    
-            interface IStats with 
-                member x.showStat() = 
-                    let oIntelVal = 
-                        match x.Intelligence with 
-                        | Some v -> v 
+        with
+            interface IStats with
+                member x.showStat() =
+                    let oIntelVal =
+                        match x.Intelligence with
+                        | Some v -> v
                         | None -> 0.00<intel>
 
                     sprintf "Weapon damage : %O - Intelligence : %O - Defense : %O - Speed : %O - Critical hit : %O - Weapon hit limit : %O - Weapon rank : %O"
                         x.Damage oIntelVal x.Defense x.Speed x.Critical x.HitLimit x.Rank
 
-        type Dagger = 
-            | RustedDagger 
-            | IronDagger   
-            | SteelDagger  
-        with   
-            override x.ToString() = 
-                match x with 
+        type Dagger =
+            | RustedDagger
+            | IronDagger
+            | SteelDagger
+        with
+            override x.ToString() =
+                match x with
                 | RustedDagger  -> "Rusted dagger"
                 | IronDagger    -> "Iron dagger"
                 | SteelDagger   -> "Steel dagger"
-            member x.WeaponStats = 
+            member x.WeaponStats =
                 match x with
                 | RustedDagger -> { Damage = 5.60<dmg>; Defense = 1.20<def>; Intelligence = None; Speed = 1.00<spd>; Critical = 0.02<ctr>; HitLimit = 20<hl>; Rank = RankE }
                 | IronDagger   -> { Damage = 9.80<dmg>; Defense = 2.30<def>; Intelligence = None; Speed = 1.10<spd>; Critical = 0.04<ctr>; HitLimit = 25<hl>; Rank = RankD }
                 | SteelDagger  -> { Damage = 13.10<dmg>; Defense = 3.00<def>; Intelligence = None; Speed = 1.15<spd>; Critical = 0.05<ctr>; HitLimit = 30<hl>; Rank = RankC }
-                
-            member x.Weight = 
-                match x with 
+
+            member x.Weight =
+                match x with
                 | RustedDagger -> 2.10<kg>
                 | IronDagger   -> 2.80<kg>
                 | SteelDagger  -> 4.25<kg>
-                
-            member x.Price = 
-                match x with 
-                | RustedDagger -> 80<usd> 
-                | IronDagger   -> 200<usd> 
-                | SteelDagger  -> 350<usd>   
 
-        type Sword = 
-            | BrokenSword 
-            | RustedSword 
-            | IronSword   
-            | SteelSword  
+            member x.Price =
+                match x with
+                | RustedDagger -> 80<usd>
+                | IronDagger   -> 200<usd>
+                | SteelDagger  -> 350<usd>
+
+        type Sword =
+            | BrokenSword
+            | RustedSword
+            | IronSword
+            | SteelSword
         with
-            override x.ToString() = 
-                match x with 
+            override x.ToString() =
+                match x with
                 | BrokenSword -> "Broken sword"
                 | RustedSword -> "Rusted sword"
                 | IronSword   -> "Iron sword"
                 | SteelSword  -> "Steel sword`"
-            member x.WeaponStats = 
+            member x.WeaponStats =
                 match x with
                 | BrokenSword -> { Damage = 5.4<dmg>; Defense = 2.50<def>; Intelligence = None; Speed = 1.2<spd>; Critical = 0.01<ctr>; HitLimit = 10<hl>; Rank = RankE }
                 | RustedSword -> { Damage = 8.75<dmg>; Defense = 2.90<def>; Intelligence = None ;Speed = 1.05<spd>; Critical = 0.03<ctr>; HitLimit = 20<hl>; Rank = RankD }
                 | IronSword   -> { Damage = 11.1<dmg>; Defense = 3.40<def>; Intelligence = None ;Speed = 1.00<spd>; Critical = 0.04<ctr>; HitLimit = 25<hl>; Rank = RankC }
                 | SteelSword  -> { Damage = 15.25<dmg>; Defense = 4.30<def>;Intelligence = None ; Speed = 0.85<spd>; Critical = 0.06<ctr>; HitLimit = 35<hl>; Rank = RankB }
-            member x.Weight = 
-                match x with 
+            member x.Weight =
+                match x with
                 | BrokenSword  -> 7.20<kg>
                 | RustedSword  -> 8.50<kg>
                 | IronSword    -> 12.35<kg>
                 | SteelSword   -> 15.00<kg>
 
-            member x.Price = 
-                match x with 
+            member x.Price =
+                match x with
                 | BrokenSword  -> 90<usd>
                 | RustedSword  -> 120<usd>
                 | IronSword    -> 250<usd>
                 | SteelSword   -> 525<usd>
 
-        type Axe = 
-            | RustedAxe        
-            | IronAxe         
-            | RustedBattleAxe 
-            | IronBattleAxe   
-            | SteelBattleAxe  
+        type Axe =
+            | RustedAxe
+            | IronAxe
+            | RustedBattleAxe
+            | IronBattleAxe
+            | SteelBattleAxe
         with
-            override x.ToString() = 
-                match x with 
+            override x.ToString() =
+                match x with
                 | RustedAxe -> "Rusted axe"
                 | IronAxe -> "Iron axe"
                 | RustedBattleAxe -> "Rusted battle axe"
@@ -287,22 +285,22 @@
                 | SteelBattleAxe -> "SteelBattleAxe"
 
             member x.Weight =
-                match x with 
+                match x with
                 | RustedAxe       -> 8.00<kg>
                 | IronAxe         -> 10.00<kg>
                 | RustedBattleAxe -> 9.00<kg>
                 | IronBattleAxe   -> 13.00<kg>
                 | SteelBattleAxe  -> 16.00<kg>
-            member x.Price = 
-                match x with 
+            member x.Price =
+                match x with
                 | RustedAxe        ->  125<usd>
                 | IronAxe          ->  280<usd>
                 | RustedBattleAxe  ->  150<usd>
                 | IronBattleAxe    ->  300<usd>
                 | SteelBattleAxe   ->  425<usd>
 
-            member x.WeaponStats = 
-                match x with 
+            member x.WeaponStats =
+                match x with
                 | RustedAxe ->          { Damage = 7.20<dmg>; Defense = 2.10<def>; Speed = -1.00<spd>;  Intelligence = None ; Critical =0.03<ctr> ; HitLimit =   20<hl>; Rank = RankE }
                 | IronAxe ->            { Damage = 11.80<dmg>; Defense = 2.90<def>; Speed = -1.50<spd>; Intelligence = None ; Critical = 0.06<ctr> ;  HitLimit = 25<hl>; Rank = RankD }
                 | RustedBattleAxe ->    { Damage = 7.10<dmg>; Defense = 2.30<def>; Speed = -1.20<spd>; Intelligence = None ; Critical = 0.04<ctr> ; HitLimit =  20<hl>; Rank = RankE }
@@ -311,50 +309,50 @@
 
         type Spear =
             | RustedSpear
-            | IronSpear  
-            | SteelSpear 
+            | IronSpear
+            | SteelSpear
         with
-            override x.ToString() = 
-                match x with 
+            override x.ToString() =
+                match x with
                 | RustedSpear -> "Rusted spear"
                 | IronSpear -> "Iron spear"
                 | SteelSpear -> "Steel spear"
-            member x.WeaponStats = 
+            member x.WeaponStats =
                 match x with
                 | RustedSpear  -> { Damage = 8.20<dmg>; Intelligence = None; Defense = -3.30<def>; Speed = -1.10<spd>; Critical = 0.05<ctr>; HitLimit = 12<hl>; Rank = RankE }
                 | IronSpear    -> { Damage = 12.00<dmg>; Intelligence = None; Defense = -4.25<def>; Speed = -1.50<spd>; Critical = 0.075<ctr>; HitLimit = 15<hl>; Rank = RankD }
-                | SteelSpear   -> { Damage = 14.75<dmg>; Intelligence = None; Defense = -5.05<def>; Speed = -1.75<spd>; Critical = 0.0925<ctr>; HitLimit = 20<hl>; Rank = RankC }               
-            member x.Weight = 
-                match x with 
+                | SteelSpear   -> { Damage = 14.75<dmg>; Intelligence = None; Defense = -5.05<def>; Speed = -1.75<spd>; Critical = 0.0925<ctr>; HitLimit = 20<hl>; Rank = RankC }
+            member x.Weight =
+                match x with
                 | RustedSpear -> 15.0<kg>
                 | IronSpear   -> 20.0<kg>
                 | SteelSpear  -> 30.0<kg>
-            member x.Price = 
+            member x.Price =
                 match x with
                 | RustedSpear  -> 200<usd>
                 | IronSpear    -> 325<usd>
-                | SteelSpear   -> 550<usd>          
+                | SteelSpear   -> 550<usd>
 
-        type Staff = 
-            | RookieStaff       
-            | AdeptStaff        
-            | SorcererStaff     
-            | NecromancerStaff  
+        type Staff =
+            | RookieStaff
+            | AdeptStaff
+            | SorcererStaff
+            | NecromancerStaff
         with
-            override x.ToString() = 
-                match x with 
+            override x.ToString() =
+                match x with
                 | RookieStaff -> "Rookie staff"
                 | AdeptStaff -> "Adept staff"
                 | SorcererStaff -> "Sorcerer staff"
                 | NecromancerStaff  -> "Necromancer staff"
-            member x.WeaponStats = 
+            member x.WeaponStats =
                 match x with
                 | RookieStaff       ->  { Damage = 3.00<dmg>; Defense = 1.50<def>; Intelligence = Some 4.00<intel>; Speed = 1.00<spd>; Critical = 0.02<ctr>; HitLimit= 10<hl>; Rank = RankE }
                 | AdeptStaff        ->{ Damage = 5.00<dmg>; Defense = 2.00<def>; Intelligence = Some 7.00<intel>; Speed = 0.80<spd>; Critical = 0.045<ctr>; HitLimit= 12<hl>; Rank = RankD }
                 | SorcererStaff     ->{ Damage = 6.70<dmg>; Defense = 4.50<def>; Intelligence = Some 9.20<intel>; Speed = 1.10<spd>; Critical = 0.075<ctr>; HitLimit = 20<hl>; Rank = RankC }
                 | NecromancerStaff  ->{ Damage = 8.00<dmg>; Defense = 5.00<def>; Intelligence = Some 13.00<intel>; Speed = 1.00<spd>; Critical = 0.00<ctr>; HitLimit = 25<hl>; Rank = RankA }
-            member x.Weight = 
-                match x with 
+            member x.Weight =
+                match x with
                 | RookieStaff       -> 2.20<kg>
                 | AdeptStaff        -> 4.20<kg>
                 | SorcererStaff     -> 5.10<kg>
@@ -366,23 +364,23 @@
                 | SorcererStaff    -> 445<usd>
                 | NecromancerStaff -> 650<usd>
 
-        type Blade = 
+        type Blade =
             | RustedLongBlade
-            | RustedKatana   
-            | IronLongBlade  
+            | RustedKatana
+            | IronLongBlade
             | CurvedLongBlade
-            | SteelKatana    
-            | SteelLongBlade 
+            | SteelKatana
+            | SteelLongBlade
         with
-            override x.ToString() = 
-                match x with 
+            override x.ToString() =
+                match x with
                 | RustedLongBlade -> "Rusted long blade"
                 | RustedKatana    -> "Rusted katana"
-                | IronLongBlade   -> "Iron long blade" 
+                | IronLongBlade   -> "Iron long blade"
                 | CurvedLongBlade  -> "Curved long blade"
                 | SteelKatana     -> "Steel katana"
-                | SteelLongBlade  -> "Steel long blade"       
-            member x.WeaponStats = 
+                | SteelLongBlade  -> "Steel long blade"
+            member x.WeaponStats =
                 match x with
                 | RustedLongBlade -> { Damage = 6.00<dmg>; Defense = 0.5<def>; Intelligence = None; Speed = 1.10<spd>; Critical = 0.01<ctr>; HitLimit = 10<hl>; Rank = RankE }
                 | RustedKatana    -> { Damage = 5.50<dmg>; Defense = 0.45<def>; Intelligence = None; Speed = 1.07<spd>; Critical = 0.02<ctr>; HitLimit = 10<hl>; Rank = RankE }
@@ -390,50 +388,50 @@
                 | CurvedLongBlade -> { Damage = 7.00<dmg>; Defense = 0.80<def>; Intelligence = None; Speed = 1.25<spd>; Critical = 0.055<ctr>; HitLimit = 10<hl>; Rank = RankD }
                 | SteelKatana     -> { Damage = 13.0<dmg>; Defense = 1.00<def>; Intelligence = None; Speed = 1.60<spd>; Critical = 0.07<ctr>; HitLimit = 15<hl>; Rank = RankC }
                 | SteelLongBlade  -> { Damage = 15.00<dmg>; Defense = 1.10<def>; Intelligence = None; Speed = 1.55<spd>; Critical = 0.085<ctr>; HitLimit = 15<hl>; Rank = RankC }
-            member x.Weight = 
-                match x with 
+            member x.Weight =
+                match x with
                 | RustedLongBlade -> 6.00<kg>
                 | RustedKatana    -> 7.75<kg>
                 | IronLongBlade   -> 14.25<kg>
                 | CurvedLongBlade -> 11.20<kg>
                 | SteelKatana     -> 16.78<kg>
                 | SteelLongBlade  -> 15.30<kg>
-            member x.Price = 
-                match x with 
+            member x.Price =
+                match x with
                 | RustedLongBlade ->  120<usd>
                 | RustedKatana    ->  100<usd>
                 | IronLongBlade   ->  215<usd>
                 | CurvedLongBlade ->  240<usd>
                 | SteelKatana     ->  350<usd>
-                | SteelLongBlade  ->  410<usd> 
+                | SteelLongBlade  ->  410<usd>
 
         type SpellbookStats = {
-            AttackRange : int 
-            Damage      : float<dmg> 
+            AttackRange : int
+            Damage      : float<dmg>
             Rank        : WeaponRank
             Uses        : int
             ManaCost    : float<mp>
         }
         with
-            interface IStats with 
-                member x.showStat() = 
+            interface IStats with
+                member x.showStat() =
                     sprintf "Damage : %O - Attack range : %O - Mana cost: %O - Number of use: %O - Rank of spell: %O" x.Damage x.AttackRange x.ManaCost x.Uses x.Rank
 
         type Spellbook =
-            | Fireball       
-            | Thunder       
-            | Frost         
-            | Hellfire      
-            | BlackFire     
-            | StormOfBlades 
+            | Fireball
+            | Thunder
+            | Frost
+            | Hellfire
+            | BlackFire
+            | StormOfBlades
         with
-            override x.ToString() =     
-                match x with 
-                | Fireball -> "Fireball" 
+            override x.ToString() =
+                match x with
+                | Fireball -> "Fireball"
                 | Thunder -> "Thunder"
-                | Frost -> "Frost" 
+                | Frost -> "Frost"
                 | Hellfire -> "Hellfire"
-                | BlackFire -> "Black fire" 
+                | BlackFire -> "Black fire"
                 | StormOfBlades -> "Storm of blades"
             member x.SpellStats =
                 match x with
@@ -442,7 +440,7 @@
                 | Frost            -> { Damage = 8.0<dmg>; AttackRange = 1; Rank = RankE; Uses = 30 ; ManaCost = 12.0<mp> }
                 | Hellfire         -> { Damage = 6.50<dmg>; AttackRange = 2; Rank = RankD; Uses = 25; ManaCost = 20.0<mp> }
                 | BlackFire        -> { Damage = 11.2<dmg>; AttackRange = 2; Rank = RankC; Uses = 20; ManaCost = 25.0<mp> }
-                | StormOfBlades    -> { Damage = 5.80<dmg>; AttackRange = 3; Rank = RankD; Uses = 30; ManaCost = 22.0<mp> }    
+                | StormOfBlades    -> { Damage = 5.80<dmg>; AttackRange = 3; Rank = RankD; Uses = 30; ManaCost = 22.0<mp> }
             member x.Weight =
                 match x with
                 | Fireball         -> 0.05<kg>
@@ -460,26 +458,26 @@
                 | BlackFire       -> 350<usd>
                 | StormOfBlades   -> 350<usd>
 
-        type Weaponry = 
-            | Dagger        of Dagger 
-            | Sword         of Sword 
+        type Weaponry =
+            | Dagger        of Dagger
+            | Sword         of Sword
             | Axe           of Axe
             | Spear         of Spear
-            | Staff         of Staff 
+            | Staff         of Staff
             | LongBlade     of Blade
             | Spellbook     of Spellbook
-        with 
-            member x.Name = 
-                match x with 
-                | Dagger d -> d.ToString() 
-                | Sword  s -> s.ToString() 
-                | Axe    a -> a.ToString() 
-                | Spear  s -> s.ToString() 
+        with
+            member x.Name =
+                match x with
+                | Dagger d -> d.ToString()
+                | Sword  s -> s.ToString()
+                | Axe    a -> a.ToString()
+                | Spear  s -> s.ToString()
                 | Staff  s -> s.ToString()
-                | LongBlade lb -> lb.ToString() 
+                | LongBlade lb -> lb.ToString()
                 | Spellbook sb -> sb.ToString()
-            member x.Price = 
-                match x with 
+            member x.Price =
+                match x with
                 | Dagger     w -> w.Price
                 | Sword      w -> w.Price
                 | Axe        w -> w.Price
@@ -497,7 +495,7 @@
                 | LongBlade  w -> w.Weight
                 | Spellbook  w -> w.Weight
 
-            member x.Stats = 
+            member x.Stats =
                 match x with
                 | Dagger     w -> w.WeaponStats :> IStats
                 | Sword      w -> w.WeaponStats :> IStats
@@ -509,10 +507,10 @@
         let computeCharacterOverallOffensive
             (rank: WeaponRank)
             (weapon: Weaponry)
-            (cStats: CharacterStats) = 
-            let strength = 
+            (cStats: CharacterStats) =
+            let strength =
                 cStats.Strength *
-                    match rank with 
+                    match rank with
                     | RankE -> 1.0100
                     | RankD -> 1.0375
                     | RankC -> 1.0925
@@ -520,28 +518,28 @@
                     | RankA -> 1.1785
                     | RankS -> 1.2105
 
-            let overallDamage = 
+            let overallDamage =
                 strength *
-                    match weapon with 
-                    | Dagger d -> 
-                        d.WeaponStats.Damage 
-                    | Sword s -> 
-                        s.WeaponStats.Damage 
-                    | Axe a -> 
+                    match weapon with
+                    | Dagger d ->
+                        d.WeaponStats.Damage
+                    | Sword s ->
+                        s.WeaponStats.Damage
+                    | Axe a ->
                         a.WeaponStats.Damage
-                    | Spear s -> 
-                        s.WeaponStats.Damage 
-                    | Staff s -> 
-                        s.WeaponStats.Damage 
-                    | LongBlade lb -> 
-                        lb.WeaponStats.Damage 
-                    | Spellbook sb -> 
-                        sb.SpellStats.Damage 
+                    | Spear s ->
+                        s.WeaponStats.Damage
+                    | Staff s ->
+                        s.WeaponStats.Damage
+                    | LongBlade lb ->
+                        lb.WeaponStats.Damage
+                    | Spellbook sb ->
+                        sb.SpellStats.Damage
             overallDamage
 
     [<AutoOpen>]
     module CharacterWearableProtection =
-        
+
         type CharacterProtectionStats = {
             Defense : float<def>
             Resistance : float<res>
@@ -550,22 +548,22 @@
             Speed  : float<spd>
             EquipmentUsage : int<eu>
         }
-        with 
-            interface IStats with 
-                member x.showStat() = 
+        with
+            interface IStats with
+                member x.showStat() =
                     sprintf "Defense : %O - Resistance : %O - Magic resistance : %O - Speed : %O - Equipment usage : %O" x.Defense x.Resistance x.MagicResist x.Speed x.EquipmentUsage
-        
-        type Hat = 
-            | SorcererHat 
-            | InfantryHat 
-            | JourneyManHelmet  
-            | RustedHelmet 
-            | MerlinsHat 
-            | IronHelmet 
-            | SteelHelmet 
-        with 
-            override x.ToString() = 
-                match x with 
+
+        type Hat =
+            | SorcererHat
+            | InfantryHat
+            | JourneyManHelmet
+            | RustedHelmet
+            | MerlinsHat
+            | IronHelmet
+            | SteelHelmet
+        with
+            override x.ToString() =
+                match x with
                 | SorcererHat -> "Sorcerer hat"
                 | InfantryHat -> "Infantry hat"
                 | JourneyManHelmet -> "Journey man helmet"
@@ -573,12 +571,12 @@
                 | MerlinsHat -> "Merlin's hat"
                 | IronHelmet -> "Iron helmet"
                 | SteelHelmet -> "Steel helmet"
-            member x.Name = 
-                match x with 
+            member x.Name =
+                match x with
                 | _ -> x.ToString()
-            
-            member x.Weight = 
-                match x with 
+
+            member x.Weight =
+                match x with
                 | SorcererHat -> 1.0<kg>
                 | InfantryHat -> 3.20<kg>
                 | JourneyManHelmet -> 2.25<kg>
@@ -587,8 +585,8 @@
                 | IronHelmet -> 6.25<kg>
                 | SteelHelmet -> 8.00<kg>
 
-            member x.CharacterProtectionStats = 
-                match x with 
+            member x.CharacterProtectionStats =
+                match x with
                 | SorcererHat       -> { Defense = 1.20<def>; Resistance = 1.30<res>; Intelligence = Some 3.00<intel>; MagicResist = 1.80<mgres>; Speed = 1.00<spd>; EquipmentUsage = 100<eu> }
                 | InfantryHat  -> { Defense = 2.20<def>; Resistance = 1.80<res>; Intelligence = None; MagicResist = 0.80<mgres>; Speed = 0.95<spd>; EquipmentUsage = 100<eu> }
                 | JourneyManHelmet -> { Defense = 5.60<def>; Resistance = 3.20<res>; Intelligence = None; MagicResist = 0.60<mgres>; Speed = 0.90<spd>; EquipmentUsage = 100<eu> }
@@ -597,252 +595,252 @@
                 | IronHelmet -> { Defense = 7.20<def>; Resistance = 3.50<res>; Intelligence = None; MagicResist = 0.40<mgres>; Speed = 0.98<spd>; EquipmentUsage = 100<eu> }
                 | SteelHelmet -> { Defense = 10.80<def>; Resistance = 4.20<res>; Intelligence = None; MagicResist = 0.40<mgres>; Speed = 0.95<spd>; EquipmentUsage = 100<eu> }
 
-        type Armor = 
-            | InfantryArmor 
-            | RustedArmor 
-            | IronArmor 
-            | SteelArmor 
+        type Armor =
+            | InfantryArmor
+            | RustedArmor
+            | IronArmor
+            | SteelArmor
             | MyrtilleArmor
-        with 
-            override x.ToString() = 
-                match x with 
-                | InfantryArmor -> "Infantry armor" 
+        with
+            override x.ToString() =
+                match x with
+                | InfantryArmor -> "Infantry armor"
                 | RustedArmor -> "Rusted armor"
                 | IronArmor   -> "Iron armor"
                 | SteelArmor  -> "Steel armor"
                 | MyrtilleArmor -> "Myrtille armor"
-            
-            member x.Weight = 
-                match x with 
+
+            member x.Weight =
+                match x with
                 | InfantryArmor  -> 6.0<kg>
-                | RustedArmor    -> 5.5<kg> 
-                | IronArmor      -> 10.0<kg> 
+                | RustedArmor    -> 5.5<kg>
+                | IronArmor      -> 10.0<kg>
                 | SteelArmor     -> 15.0<kg>
-                | MyrtilleArmor  -> 22.75<kg> 
-            member x.Name = 
-                match x with 
+                | MyrtilleArmor  -> 22.75<kg>
+            member x.Name =
+                match x with
                 | _ -> x.ToString()
 
-            member x.CharacterProtectionStats = 
-                match x with 
+            member x.CharacterProtectionStats =
+                match x with
                 | InfantryArmor -> { Defense = 6.50<def>; Resistance = 2.20<res>; Intelligence = None; MagicResist = 0.00<mgres>; Speed = 0.99<spd>; EquipmentUsage = 100<eu> }
                 | RustedArmor   -> { Defense = 4.20<def>; Resistance = 1.10<res>; Intelligence = None; MagicResist = 0.30<mgres>; Speed = 1.00<spd>; EquipmentUsage = 50<eu> }
                 | IronArmor     -> { Defense = 12.00<def>; Resistance = 4.30<res>; Intelligence = None; MagicResist = 1.00<mgres>; Speed = 0.975<spd>; EquipmentUsage = 100<eu> }
                 | SteelArmor    -> { Defense = 17.40<def>; Resistance = 6.10<res>; Intelligence = None; MagicResist = 2.30<mgres>; Speed = 0.945<spd>; EquipmentUsage = 100<eu> }
                 | MyrtilleArmor -> { Defense = 23.55<def>; Resistance = 10.10<res>; Intelligence = None; MagicResist = 5.70<mgres>; Speed = 0.9725<spd>; EquipmentUsage = 100<eu> }
-            
-        type Pants = 
-            | InfantryPants 
-            | IronPants 
-            | SteelPants 
-            | MyrtillePants 
-        with 
-            override x.ToString() = 
-                match x with 
-                | InfantryPants -> "Infantry pants" 
-                | IronPants -> "Iron pants" 
-                | SteelPants -> "Steel pants" 
-                | MyrtillePants -> "Myrtille pants" 
 
-            member x.Name :string=     
-                match x with 
+        type Pants =
+            | InfantryPants
+            | IronPants
+            | SteelPants
+            | MyrtillePants
+        with
+            override x.ToString() =
+                match x with
+                | InfantryPants -> "Infantry pants"
+                | IronPants -> "Iron pants"
+                | SteelPants -> "Steel pants"
+                | MyrtillePants -> "Myrtille pants"
+
+            member x.Name :string=
+                match x with
                 | _ -> x.ToString()
 
-            member x.Weight = 
-                match x with 
+            member x.Weight =
+                match x with
                 | InfantryPants -> 4.00<kg>
-                | IronPants -> 5.75<kg> 
-                | SteelPants -> 10.80<kg> 
-                | MyrtillePants -> 15.20<kg> 
+                | IronPants -> 5.75<kg>
+                | SteelPants -> 10.80<kg>
+                | MyrtillePants -> 15.20<kg>
 
-            member x.CharacterProtectionStats = 
-                match x with 
-                | InfantryPants -> 
+            member x.CharacterProtectionStats =
+                match x with
+                | InfantryPants ->
                     { Defense = 0.85<def>; Resistance = 0.30<res>; Intelligence = None; MagicResist = 0.00<mgres>; Speed = 0.99<spd>; EquipmentUsage = 100<eu> }
                 | IronPants -> { Defense = 3.50<def>; Resistance = 1.20<res>; Intelligence = None; MagicResist = 0.50<mgres>; Speed = 0.98<spd>; EquipmentUsage = 100<eu> }
                 | SteelPants -> { Defense = 5.10<def>; Resistance = 2.00<res>; Intelligence = None; MagicResist = 1.00<mgres>; Speed = 0.95<spd>; EquipmentUsage = 100<eu> }
                 | MyrtillePants -> { Defense = 6.50<def>; Resistance = 2.70<res>; Intelligence = None; MagicResist = 3.00<mgres>; Speed = 0.9765<spd>; EquipmentUsage = 100<eu> }
 
-        type Gauntlets = 
-            | InfantryGauntless 
-            | RustedGauntless 
-            | IronGauntless 
-            | SteelGauntless 
-        with 
-            override x.ToString() = 
-                match x with 
+        type Gauntlets =
+            | InfantryGauntless
+            | RustedGauntless
+            | IronGauntless
+            | SteelGauntless
+        with
+            override x.ToString() =
+                match x with
                 | InfantryGauntless -> "Infantry gauntlets"
                 | RustedGauntless -> "Rusted gauntlets"
                 | IronGauntless -> "Iron gauntlets"
                 | SteelGauntless -> "Steel gauntlets"
-            member x.Name = 
-                match x with 
+            member x.Name =
+                match x with
                 | _ -> x.ToString()
-            member x.Weight = 
-                match x with 
+            member x.Weight =
+                match x with
                 | InfantryGauntless -> 1.00<kg>
-                | RustedGauntless -> 1.70<kg> 
-                | IronGauntless -> 3.20<kg> 
+                | RustedGauntless -> 1.70<kg>
+                | IronGauntless -> 3.20<kg>
                 | SteelGauntless -> 6.55<kg>
-            member x.CharacterProtectionStats = 
-                match x with 
-                | InfantryGauntless -> 
+            member x.CharacterProtectionStats =
+                match x with
+                | InfantryGauntless ->
                     { Defense = 0.85<def>; Resistance = 0.15<res>; Intelligence = None; MagicResist = 0.10<mgres>; Speed = 0.995<spd>; EquipmentUsage = 100<eu> }
-                | RustedGauntless -> 
+                | RustedGauntless ->
                     { Defense = 1.2<def>; Resistance = 0.45<res>; Intelligence = None; MagicResist = 0.20<mgres>; Speed = 0.99<spd>; EquipmentUsage = 50<eu> }
-                | IronGauntless -> 
+                | IronGauntless ->
                     { Defense = 3.65<def>; Resistance = 0.85<res>; Intelligence = None; MagicResist = 0.25<mgres>; Speed = 0.975<spd>; EquipmentUsage = 100<eu> }
-                | SteelGauntless -> 
+                | SteelGauntless ->
                     { Defense = 5.15<def>; Resistance = 1.35<res>; Intelligence = None; MagicResist = 0.45<mgres>; Speed = 0.95<spd>; EquipmentUsage = 100<eu> }
 
         type RingStats = {
             ExtraStrength : float<str> option
-            ExtraDamage   : float<dmg> option 
+            ExtraDamage   : float<dmg> option
             ExtraHealth   : float<hp> option
             ExtraMana     : float<mp> option
         }
         with
-            interface IStats with 
-                member x.showStat() = 
+            interface IStats with
+                member x.showStat() =
                     sprintf ""
-            static member Initial = 
+            static member Initial =
                 { ExtraDamage = None; ExtraStrength = None; ExtraHealth = None; ExtraMana = None }
 
-        type Ring = 
-            | ExtraStrenghtRing 
-            | ExtraDamageRing 
-            | ExtraHealthRing 
-            | ExtraManaRing  
-        with 
-            override x.ToString() =     
-                match x with 
+        type Ring =
+            | ExtraStrenghtRing
+            | ExtraDamageRing
+            | ExtraHealthRing
+            | ExtraManaRing
+        with
+            override x.ToString() =
+                match x with
                 | ExtraStrenghtRing -> "Extra strenght ring"
                 | ExtraDamageRing -> "Extra damage ring"
                 | ExtraHealthRing -> "Extra health ring"
                 | ExtraManaRing -> "Extra mana ring"
 
-            member x.Name = 
-                match x with 
-                | _ -> x.ToString() 
+            member x.Name =
+                match x with
+                | _ -> x.ToString()
 
-            member x.Weight : float<kg> = 
-                match x with 
-                | _ -> 0.75<kg> 
+            member x.Weight : float<kg> =
+                match x with
+                | _ -> 0.75<kg>
 
-            member x.CharacterProtectionStat = 
-                match x with 
+            member x.CharacterProtectionStat =
+                match x with
                 | ExtraDamageRing ->  { RingStats.Initial with ExtraDamage = Some 5.00<dmg> }
                 | ExtraStrenghtRing -> { RingStats.Initial with ExtraStrength = Some 4.50<str> }
                 | ExtraHealthRing -> { RingStats.Initial with ExtraHealth = Some 12.00<hp> }
                 | ExtraManaRing -> { RingStats.Initial with ExtraMana = Some 7.00<mp> }
 
         type ShieldStats = {
-            Defense : float<def> 
-            Resistance :float<res> 
-            Speed   : float<spd> 
+            Defense : float<def>
+            Resistance :float<res>
+            Speed   : float<spd>
             MagicResist : float<mgres>
             ShieldRank  : WeaponRank
             EquipmentUsage : int<eu>
         }
         with
-            interface IStats with 
-                member x.showStat() = 
+            interface IStats with
+                member x.showStat() =
                     sprintf "Defense : %O - Resistance : %O - Magic resistance : %O - Equipment usage : %O" x.Defense x.Resistance x.MagicResist x.EquipmentUsage
 
-        type Shield = 
-            | RustedShield 
-            | SmallShield 
-            | KnightShield 
-            | HeavyShield 
-            | SteelShield 
-        with 
-            override x.ToString()  = 
-                match x with 
-                | RustedShield -> "Rusted shield" 
-                | SmallShield -> "Small shield" 
-                | KnightShield -> "Knight shield" 
-                | HeavyShield -> "Heavy shield" 
-                | SteelShield -> "Steel shield" 
-
-            member x.Name = 
-                 match x with 
-                 | _ -> x.ToString()             
-            member x.Weight = 
-                match x with 
-                | RustedShield -> 5.00<kg> 
-                | SmallShield -> 3.25<kg> 
-                | KnightShield -> 6.80<kg> 
-                | HeavyShield -> 12.50<kg> 
-                | SteelShield -> 10.80<kg> 
-
-            member x.CharacterProtectionStat = 
-                match x with 
-                | RustedShield -> 
-                    { Defense = 5.60<def>; Resistance = 3.10<res>; Speed = 0.96<spd>; MagicResist = 1.85<mgres>; ShieldRank = RankE; EquipmentUsage = 50<eu> } 
-                | SmallShield -> 
-                    { Defense = 3.80<def>; Resistance = 2.70<res>; Speed = 0.985<spd>; MagicResist = 0.50<mgres>; ShieldRank = RankE; EquipmentUsage = 100<eu> } 
-                | KnightShield -> 
-                    { Defense = 9.80<def>; Resistance = 5.10<res>; Speed = 0.94<spd>; MagicResist = 3.40<mgres>; ShieldRank = RankC; EquipmentUsage = 100<eu> } 
-                | HeavyShield -> 
-                    { Defense = 12.75<def>; Resistance = 6.40<res>; Speed = 0.88<spd>; MagicResist = 4.60<mgres>; ShieldRank = RankC; EquipmentUsage = 100<eu> } 
-                | SteelShield -> 
-                    { Defense = 17.20<def>; Resistance = 9.30<res>; Speed = 0.93<spd>; MagicResist = 5.90<mgres>; ShieldRank = RankB; EquipmentUsage = 100<eu> } 
-
-        type CharacterProtection = 
-            | Shield        of Shield 
-            | Ring          of Ring 
-            | Gloves        of Gauntlets 
-            | Legs          of Pants
-            | Armor         of Armor 
-            | Hat           of Hat 
-
-        with 
-            member x.Name = 
-                match x with 
-                | Shield s -> s.Name 
-                | Ring r -> r.Name 
-                | Gloves g -> g.Name 
-                | Legs l -> l.Name 
-                | Armor a -> a.Name 
-                | Hat h -> h.Name 
-            
-            member x.Weight = 
+        type Shield =
+            | RustedShield
+            | SmallShield
+            | KnightShield
+            | HeavyShield
+            | SteelShield
+        with
+            override x.ToString()  =
                 match x with
-                | Shield s -> s.Weight 
-                | Ring r -> r.Weight 
-                | Gloves g -> g.Weight 
-                | Legs l -> l.Weight 
-                | Armor a -> a.Weight 
-                | Hat h -> h.Weight 
+                | RustedShield -> "Rusted shield"
+                | SmallShield -> "Small shield"
+                | KnightShield -> "Knight shield"
+                | HeavyShield -> "Heavy shield"
+                | SteelShield -> "Steel shield"
 
-            member x.ProtectionStats = 
-                match x with 
+            member x.Name =
+                 match x with
+                 | _ -> x.ToString()
+            member x.Weight =
+                match x with
+                | RustedShield -> 5.00<kg>
+                | SmallShield -> 3.25<kg>
+                | KnightShield -> 6.80<kg>
+                | HeavyShield -> 12.50<kg>
+                | SteelShield -> 10.80<kg>
+
+            member x.CharacterProtectionStat =
+                match x with
+                | RustedShield ->
+                    { Defense = 5.60<def>; Resistance = 3.10<res>; Speed = 0.96<spd>; MagicResist = 1.85<mgres>; ShieldRank = RankE; EquipmentUsage = 50<eu> }
+                | SmallShield ->
+                    { Defense = 3.80<def>; Resistance = 2.70<res>; Speed = 0.985<spd>; MagicResist = 0.50<mgres>; ShieldRank = RankE; EquipmentUsage = 100<eu> }
+                | KnightShield ->
+                    { Defense = 9.80<def>; Resistance = 5.10<res>; Speed = 0.94<spd>; MagicResist = 3.40<mgres>; ShieldRank = RankC; EquipmentUsage = 100<eu> }
+                | HeavyShield ->
+                    { Defense = 12.75<def>; Resistance = 6.40<res>; Speed = 0.88<spd>; MagicResist = 4.60<mgres>; ShieldRank = RankC; EquipmentUsage = 100<eu> }
+                | SteelShield ->
+                    { Defense = 17.20<def>; Resistance = 9.30<res>; Speed = 0.93<spd>; MagicResist = 5.90<mgres>; ShieldRank = RankB; EquipmentUsage = 100<eu> }
+
+        type CharacterProtection =
+            | Shield        of Shield
+            | Ring          of Ring
+            | Gloves        of Gauntlets
+            | Legs          of Pants
+            | Armor         of Armor
+            | Hat           of Hat
+
+        with
+            member x.Name =
+                match x with
+                | Shield s -> s.Name
+                | Ring r -> r.Name
+                | Gloves g -> g.Name
+                | Legs l -> l.Name
+                | Armor a -> a.Name
+                | Hat h -> h.Name
+
+            member x.Weight =
+                match x with
+                | Shield s -> s.Weight
+                | Ring r -> r.Weight
+                | Gloves g -> g.Weight
+                | Legs l -> l.Weight
+                | Armor a -> a.Weight
+                | Hat h -> h.Weight
+
+            member x.ProtectionStats =
+                match x with
                 | Shield s -> s.CharacterProtectionStat :> IStats
                 | Ring r -> r.CharacterProtectionStat :> IStats
                 | Gloves g -> g.CharacterProtectionStats :> IStats
                 | Legs l -> l.CharacterProtectionStats :> IStats
                 | Armor a -> a.CharacterProtectionStats :> IStats
-                | Hat h -> h.CharacterProtectionStats   :> IStats      
+                | Hat h -> h.CharacterProtectionStats   :> IStats
     [<AutoOpen>]
-    module ExccesItems =    
+    module ExccesItems =
         type ImmutableStack<'T> =
-            | Empty 
+            | Empty
             | Stack of 'T * ImmutableStack<'T>
-        with 
+        with
             member s.Push x = Stack(x, s)
-            member s.Pop() = 
+            member s.Pop() =
                 match s with
                 | Empty -> failwith "Underflow"
                 | Stack(t,_) -> t
-            member s.Top() = 
+            member s.Top() =
                 match s with
                 | Empty -> failwith "Contain no elements"
                 | Stack(_,st) -> st
-            member s.isEmpty = 
+            member s.isEmpty =
                 match s with
                 | Empty -> true
                 | _ -> false
-            member s.All() = 
+            member s.All() =
                 let rec loop acc = function
                     | Empty -> acc
                     | Stack(t,st) -> loop (t::acc) st
@@ -852,108 +850,98 @@
     [<AutoOpen>]
     module Inventory =
 
-        type GameItem = 
-            | Consummable   of ConsummableItem * int 
+        type GameItem =
+            | Consummable   of ConsummableItem * int
             | Weapon        of Weaponry * int
             | Protection    of CharacterProtection * int
-        with 
-            member x.Quantity = 
-                match x with 
-                | Consummable (_, q) -> q 
-                | Weapon (_,q) -> q 
-                | Protection (_,q) -> q 
-            member x.updateQuantity 
-                (value: int) 
-                (provenance: ItemVariationProvenance) : GameItem = 
-                let value = 
-                    match provenance with 
-                    | FromTheShop -> value 
+        with
+            member x.Quantity =
+                match x with
+                | Consummable (_, q) -> q
+                | Weapon (_,q) -> q
+                | Protection (_,q) -> q
+            member x.updateQuantity
+                (value: int)
+                (provenance: ItemVariationProvenance) : GameItem =
+                let value =
+                    match provenance with
+                    | FromTheShop -> value
                     | FromTheInventory -> value * -1
-                match x with 
-                | Consummable (ci, q) -> 
-                    Consummable(ci, q + value) 
-                | Weapon (w, q) -> 
+                match x with
+                | Consummable (ci, q) ->
+                    Consummable(ci, q + value)
+                | Weapon (w, q) ->
                     Weapon(w, q + value)
-                | Protection (p, q) -> 
+                | Protection (p, q) ->
                     Protection(p, q + value)
-            member x.Name = 
-                match x with 
-                | _ -> x.Name 
-            member x.Weight : float<kg>= 
-                match x with 
+            member x.Name =
+                match x with
+                | _ -> x.Name
+            member x.Weight : float<kg>=
+                match x with
                 | _ -> x.Weight
-        let makeBagItemsDistinct (bag: GameItem array) = 
+        let makeBagItemsDistinct (bag: GameItem array) =
             bag |> Seq.distinct |> Seq.toArray
-        
+
         type Inventory = {
             Bag : GameItem array
             Weight: float<kg>
             Excess : ImmutableStack<GameItem>
         }
-        with 
+        with
             member x.filterFromLightestToHeaviest() =
                 x.Bag |> Array.sortBy(fun item -> item.Weight)
-            member x.filterFromHeaviestToLightest() = 
+            member x.filterFromHeaviestToLightest() =
                 x.Bag  |> Array.sortBy (fun x -> -x.Weight - 1.0<kg>) // Sort in a descending order
-            member x.isBagTooHeavy() = 
+            member x.isBagTooHeavy() =
                 x.Weight > MaxWeight
-            member x.addItem (gi : GameItem): Inventory = 
+            member x.addItem (gi : GameItem): Inventory =
                 if not (x.isBagTooHeavy()) then { x with Excess = x.Excess.Push gi }
                 elif (x.Weight + gi.Weight) >= MaxWeight then x
-                else 
+                else
                     let oItemIndex = x.Bag |> Array.tryFindIndex(fun x -> x = gi)
-                    match oItemIndex with 
-                    | Some index -> 
-                        let item = x.Bag.[index] 
+                    match oItemIndex with
+                    | Some index ->
+                        let item = x.Bag.[index]
                         let item = item.updateQuantity gi.Quantity FromTheShop
                         let bag =  x.Bag
                         bag.[index] <- item
                         let itemTotalWeight = gi.Weight * (gi.Quantity |> float)
                         { x with
-                             Bag = bag 
+                             Bag = bag
                              Weight = x.Weight + itemTotalWeight
                         }
-                    | None -> 
+                    | None ->
                         let newBag = x.Bag |> Array.append [|gi|] |> makeBagItemsDistinct
                         let itemTotalWeight = gi.Weight * (gi.Quantity |> float)
-                        let inventory = { x with 
-                                            Bag = newBag 
+                        let inventory = { x with
+                                            Bag = newBag
                                             Weight = x.Weight + itemTotalWeight
                                         }
                         inventory
-            member x.addItems (giArr: GameItem array) = 
+            member x.addItems (giArr: GameItem array) =
                 let mutable inventory = x
-                for item in giArr do 
+                for item in giArr do
                     inventory <- inventory.addItem item
                 inventory
-            member x.dropItem (item: GameItem) = 
+            member x.dropItem (item: GameItem) =
                 let oItemIndex = x.Bag |> Array.tryFindIndex (fun x -> x = item)
-                oItemIndex 
-                |> Option.bind(fun index ->     
+                oItemIndex
+                |> Option.bind(fun index ->
                     let bag = x.Bag |> Array.filter( (<>) x.Bag.[index])
                     let inventory = { x with Bag = bag }
                     Some { inventory with Weight = inventory.Weight - item.Weight * (item.Quantity |> float) }
                 )
 
-            member x.canItemsBeRemovedFromExcess() =    
+            member x.canItemsBeRemovedFromExcess() =
                 not (x.isBagTooHeavy() && x.Excess.isEmpty)
-            member x.removeItemFromExcess() =   
-                if x.canItemsBeRemovedFromExcess() then 
-                    let mutable inventory = x 
-                    while (inventory.canItemsBeRemovedFromExcess()) do 
+
+            member x.removeItemFromExcess() =
+                if x.canItemsBeRemovedFromExcess() then
+                    let mutable inventory = x
+                    while (inventory.canItemsBeRemovedFromExcess()) do
                         let excessItem = inventory.Excess.Pop()
                         inventory <- inventory.addItem excessItem
                     inventory
-                else 
+                else
                     x
-
-        
-        type Equipment = {
-            Hat : Hat 
-            Armor : Armor 
-            Legs  : Pants 
-            Hands : Gauntlets 
-            Ring  : Ring 
-            Weapon : Weaponry
-            Shield : Shield option
-        }

--- a/A game of light and shadows/GLSCore/InventoryItems.fs
+++ b/A game of light and shadows/GLSCore/InventoryItems.fs
@@ -8,7 +8,7 @@
     //Represents unit for currency
     [<Measure>] type usd
 
-    // units of measure representing the character and weapon stats
+    // units of measure representing the character and equipment stats
     [<Measure>] type dmg // damage
     [<Measure>] type def // defense
     [<Measure>] type str // strenght 
@@ -23,16 +23,7 @@
     [<Measure>] type hl // hit limit
     [<Measure>] type hp // health points 
     [<Measure>] type mp // mana points 
- 
-    let removeUnitFromFloat (x: float<_>) =
-        float x 
-
-    let removeUnitFromInt (x: int<_>) =
-        int x
-
-    //Max weight of the inventory bag
-    [<Literal>] 
-    let MaxWeight = 500.00<kg>
+    [<Measure>] type eu // equipment usage
 
     type IStats = 
         abstract member showStat : unit -> string
@@ -60,7 +51,8 @@
                 let lifePoints = hitPoint * 1.0<hp>
                 let reducedLife = { x with CurrentLife = x.CurrentLife - lifePoints }
                 (reducedLife :> IEnergyPoint)
-
+        member x.raiseMaxLife (healthPoints: float<hp>) = 
+            { CurrentLife = x.CurrentLife + healthPoints; MaxLife = x.MaxLife + healthPoints }
         member x.isCharacterDead() = 
             x.CurrentLife <= 0.0<hp>
 
@@ -79,8 +71,25 @@
             member x.reducePoints (reducePoint: float) = 
                 let manaPoints = reducePoint * 1.0<mp>
                 let reducedLife = { x with CurrentMana = x.CurrentMana - manaPoints }
-                (reducedLife :> IEnergyPoint)      
-       
+                (reducedLife :> IEnergyPoint)        
+        member x.canCharacterPerformMagic() =   
+             x.CurrentMana > 0.00<mp>
+        member x.capManaAtZero() : ManaPoint = 
+            if x.CurrentMana < 0.00<mp> then 
+                { x with CurrentMana = 0.00<mp>}
+            else 
+                x 
+        member x.raiseMaxMana (manaPoints: float<mp>) = 
+            { CurrentMana = x.CurrentMana + manaPoints; MaxMana = x.MaxMana + manaPoints }
+
+     type WeaponRank = 
+        | RankE 
+        | RankD
+        | RankC
+        | RankB 
+        | RankA
+        | RankS
+
     type CharacterStats = {
         Health          : HealthPoint
         Mana            : ManaPoint 
@@ -99,507 +108,799 @@
                 sprintf "Max health : %O - Max mana : %O - Strenght : %O - Defense : %O - Magic power : %O - Resistance : %O - Magic resistance : %O - Evade : %O - Luck : %O" x.Health.MaxLife x.Mana.MaxMana x.Strength x.Defense x.MagicPower x.Resistance x.MagicResist x.Evade x.Luck
         member x.applyTemporaryDefense (tPoints: int<def>) = 
             { x with Defense = x.Defense + tPoints }
-   
-    type WeaponRank = 
-        | RankE 
-        | RankD
-        | RankC
-        | RankB 
-        | RankA
-        | RankS
+    let removeUnitFromFloat (x: float<_>) =
+        float x 
+    let removeUnitFromInt (x: int<_>) =
+        int x
 
-    type WeaponStat = {
-        Damage : float<dmg>
-        Intelligence : float<intel> option
-        Defense : float<def> 
-        Speed : float<spd> 
-        Critical : float<ctr>
-        HitLimit : int<hl> 
-        Rank : WeaponRank
-    }
-    with    
-        interface IStats with 
-            member x.showStat() = 
-                let oIntelVal = 
-                    match x.Intelligence with 
-                    | Some v -> v 
-                    | None -> 0.00<intel>
+    //Max weight of the inventory bag
+    [<Literal>] 
+    let MaxWeight = 500.00<kg>
 
-                sprintf "Weapon damage : %O - Intelligence : %O - Defense : %O - Speed : %O - Critical hit : %O - Weapon hit limit : %O - Weapon rank : %O"
-                    x.Damage oIntelVal x.Defense x.Speed x.Critical x.HitLimit x.Rank
+    [<AutoOpen>]
+    module ConsummableItems = 
+        type ItemVariationProvenance = 
+            | FromTheShop
+            | FromTheInventory
 
-    type ItemVariationProvenance = 
-        | FromTheShop
-        | FromTheInventory
+        type ConsummableItem = 
+            | HealthPotion        
+            | HighHealthPotion   
+            | MegaHealthPotion   
+            | Elixir              
+            | HighElixir          
+            | MegaElixir          
+            | PhoenixFeather      
+            | MedicinalHerb       
+            override x.ToString() = 
+                match x with 
+                | HealthPotion     -> "Health Potion"
+                | HighHealthPotion  -> "High Health Potion"
+                | MegaHealthPotion -> "Mega Health Potion"
+                | Elixir            -> "Elixir"
+                | HighElixir        -> "High Elixir"
+                | MegaElixir        -> "Mega Elixir"
+                | PhoenixFeather    -> "Phoenix Feather"
+                | MedicinalHerb     -> "Medicinal Herb"
 
-    type ConsummableItem = 
-        | HealthPotion        
-        | HighHealthPotion   
-        | MegaHealthPotion   
-        | Elixir              
-        | HighElixir          
-        | MegaElixir          
-        | PhoenixFeather      
-        | MedicinalHerb       
-        override x.ToString() = 
-            match x with 
-            | HealthPotion     -> "Health Potion"
-            | HighHealthPotion  -> "High Health Potion"
-            | MegaHealthPotion -> "Mega Health Potion"
-            | Elixir            -> "Elixir"
-            | HighElixir        -> "High Elixir"
-            | MegaElixir        -> "Mega Elixir"
-            | PhoenixFeather    -> "Phoenix Feather"
-            | MedicinalHerb     -> "Medicinal Herb"
-        member x.Weight = 
-            match x with 
-            | HealthPotion       -> 0.02<kg>
-            | HighHealthPotion   -> 0.03<kg>
-            | MegaHealthPotion   -> 0.05<kg>
-            | Elixir             -> 0.02<kg>
-            | HighElixir         -> 0.03<kg>
-            | MegaElixir         -> 0.05<kg>
-            | PhoenixFeather     -> 0.05<kg>
-            | MedicinalHerb      -> 0.03<kg>
+            member x.Name = 
+                match x with 
+                | _ -> x.ToString()
 
-        member x.Price = 
-            match x with 
-            | HealthPotion       -> 100<usd>
-            | HighHealthPotion   -> 150<usd>
-            | MegaHealthPotion   -> 225<usd>
-            | Elixir             -> 125<usd>
-            | HighElixir         -> 175<usd>
-            | MegaElixir         -> 275<usd>
-            | PhoenixFeather     -> 350<usd>
-            | MedicinalHerb      -> 50<usd>
+            member x.Weight = 
+                match x with 
+                | HealthPotion       -> 0.02<kg>
+                | HighHealthPotion   -> 0.03<kg>
+                | MegaHealthPotion   -> 0.05<kg>
+                | Elixir             -> 0.02<kg>
+                | HighElixir         -> 0.03<kg>
+                | MegaElixir         -> 0.05<kg>
+                | PhoenixFeather     -> 0.05<kg>
+                | MedicinalHerb      -> 0.03<kg>
 
-        member x.ConsummeItem (characterStat: CharacterStats)= 
-            match x with 
-            | HealthPotion      -> { characterStat with  Health = (characterStat.Health :> IEnergyPoint).raisePoints 15.0:?> HealthPoint }
-            | HighHealthPotion   -> { characterStat with Health = (characterStat.Health :> IEnergyPoint).raisePoints 30.0 :?> HealthPoint }
-            | MegaHealthPotion   -> { characterStat with Health = (characterStat.Health :> IEnergyPoint).raisePoints 50.0 :?> HealthPoint }
-            | Elixir             -> { characterStat with Mana = (characterStat.Health :> IEnergyPoint).raisePoints 10.0 :?> ManaPoint }
-            | HighElixir         -> { characterStat with Mana = (characterStat.Health :> IEnergyPoint).raisePoints 20.0 :?> ManaPoint }
-            | MegaElixir         -> { characterStat with Mana = (characterStat.Health :> IEnergyPoint).raisePoints 30.0 :?> ManaPoint }
-            | PhoenixFeather     -> 
-                if not (characterStat.Health.isCharacterDead()) then characterStat
+            member x.Price = 
+                match x with 
+                | HealthPotion       -> 100<usd>
+                | HighHealthPotion   -> 150<usd>
+                | MegaHealthPotion   -> 225<usd>
+                | Elixir             -> 125<usd>
+                | HighElixir         -> 175<usd>
+                | MegaElixir         -> 275<usd>
+                | PhoenixFeather     -> 350<usd>
+                | MedicinalHerb      -> 50<usd>
+
+            member x.ConsummeItem (characterStat: CharacterStats)= 
+                match x with 
+                | HealthPotion      -> { characterStat with  Health = (characterStat.Health :> IEnergyPoint).raisePoints 15.0:?> HealthPoint }
+                | HighHealthPotion   -> { characterStat with Health = (characterStat.Health :> IEnergyPoint).raisePoints 30.0 :?> HealthPoint }
+                | MegaHealthPotion   -> { characterStat with Health = (characterStat.Health :> IEnergyPoint).raisePoints 50.0 :?> HealthPoint }
+                | Elixir             -> { characterStat with Mana = (characterStat.Health :> IEnergyPoint).raisePoints 10.0 :?> ManaPoint }
+                | HighElixir         -> { characterStat with Mana = (characterStat.Health :> IEnergyPoint).raisePoints 20.0 :?> ManaPoint }
+                | MegaElixir         -> { characterStat with Mana = (characterStat.Health :> IEnergyPoint).raisePoints 30.0 :?> ManaPoint }
+                | PhoenixFeather     -> 
+                    if not (characterStat.Health.isCharacterDead()) then characterStat
+                    else 
+                        { characterStat with 
+                            Health = (characterStat.Health :> IEnergyPoint).raisePoints ((removeUnitFromFloat characterStat.Health.MaxLife) * 0.50) :?> HealthPoint
+                            Mana = (characterStat.Mana :> IEnergyPoint).raisePoints ((removeUnitFromFloat characterStat.Mana.MaxMana) * 0.50) :?> ManaPoint
+                        }
+
+                | MedicinalHerb ->  { characterStat with Health = (characterStat.Health :> IEnergyPoint).raisePoints 5.0 :?> HealthPoint }
+
+
+    [<AutoOpen>]
+    module Weapons = 
+        type WeaponStat = {
+            Damage : float<dmg>
+            Intelligence : float<intel> option
+            Defense : float<def> 
+            Speed : float<spd> 
+            Critical : float<ctr>
+            HitLimit : int<hl> 
+            Rank : WeaponRank
+        }
+        with    
+            interface IStats with 
+                member x.showStat() = 
+                    let oIntelVal = 
+                        match x.Intelligence with 
+                        | Some v -> v 
+                        | None -> 0.00<intel>
+
+                    sprintf "Weapon damage : %O - Intelligence : %O - Defense : %O - Speed : %O - Critical hit : %O - Weapon hit limit : %O - Weapon rank : %O"
+                        x.Damage oIntelVal x.Defense x.Speed x.Critical x.HitLimit x.Rank
+
+        type Dagger = 
+            | RustedDagger 
+            | IronDagger   
+            | SteelDagger  
+        with   
+            override x.ToString() = 
+                match x with 
+                | RustedDagger  -> "Rusted dagger"
+                | IronDagger    -> "Iron dagger"
+                | SteelDagger   -> "Steel dagger"
+            member x.WeaponStats = 
+                match x with
+                | RustedDagger -> { Damage = 5.60<dmg>; Defense = 1.20<def>; Intelligence = None; Speed = 1.00<spd>; Critical = 0.02<ctr>; HitLimit = 20<hl>; Rank = RankE }
+                | IronDagger   -> { Damage = 9.80<dmg>; Defense = 2.30<def>; Intelligence = None; Speed = 1.10<spd>; Critical = 0.04<ctr>; HitLimit = 25<hl>; Rank = RankD }
+                | SteelDagger  -> { Damage = 13.10<dmg>; Defense = 3.00<def>; Intelligence = None; Speed = 1.15<spd>; Critical = 0.05<ctr>; HitLimit = 30<hl>; Rank = RankC }
+                
+            member x.Weight = 
+                match x with 
+                | RustedDagger -> 2.10<kg>
+                | IronDagger   -> 2.80<kg>
+                | SteelDagger  -> 4.25<kg>
+                
+            member x.Price = 
+                match x with 
+                | RustedDagger -> 80<usd> 
+                | IronDagger   -> 200<usd> 
+                | SteelDagger  -> 350<usd>   
+
+        type Sword = 
+            | BrokenSword 
+            | RustedSword 
+            | IronSword   
+            | SteelSword  
+        with
+            override x.ToString() = 
+                match x with 
+                | BrokenSword -> "Broken sword"
+                | RustedSword -> "Rusted sword"
+                | IronSword   -> "Iron sword"
+                | SteelSword  -> "Steel sword`"
+            member x.WeaponStats = 
+                match x with
+                | BrokenSword -> { Damage = 5.4<dmg>; Defense = 2.50<def>; Intelligence = None; Speed = 1.2<spd>; Critical = 0.01<ctr>; HitLimit = 10<hl>; Rank = RankE }
+                | RustedSword -> { Damage = 8.75<dmg>; Defense = 2.90<def>; Intelligence = None ;Speed = 1.05<spd>; Critical = 0.03<ctr>; HitLimit = 20<hl>; Rank = RankD }
+                | IronSword   -> { Damage = 11.1<dmg>; Defense = 3.40<def>; Intelligence = None ;Speed = 1.00<spd>; Critical = 0.04<ctr>; HitLimit = 25<hl>; Rank = RankC }
+                | SteelSword  -> { Damage = 15.25<dmg>; Defense = 4.30<def>;Intelligence = None ; Speed = 0.85<spd>; Critical = 0.06<ctr>; HitLimit = 35<hl>; Rank = RankB }
+            member x.Weight = 
+                match x with 
+                | BrokenSword  -> 7.20<kg>
+                | RustedSword  -> 8.50<kg>
+                | IronSword    -> 12.35<kg>
+                | SteelSword   -> 15.00<kg>
+
+            member x.Price = 
+                match x with 
+                | BrokenSword  -> 90<usd>
+                | RustedSword  -> 120<usd>
+                | IronSword    -> 250<usd>
+                | SteelSword   -> 525<usd>
+
+        type Axe = 
+            | RustedAxe        
+            | IronAxe         
+            | RustedBattleAxe 
+            | IronBattleAxe   
+            | SteelBattleAxe  
+        with
+            override x.ToString() = 
+                match x with 
+                | RustedAxe -> "Rusted axe"
+                | IronAxe -> "Iron axe"
+                | RustedBattleAxe -> "Rusted battle axe"
+                | IronBattleAxe -> "Iron battle axe"
+                | SteelBattleAxe -> "SteelBattleAxe"
+
+            member x.Weight =
+                match x with 
+                | RustedAxe       -> 8.00<kg>
+                | IronAxe         -> 10.00<kg>
+                | RustedBattleAxe -> 9.00<kg>
+                | IronBattleAxe   -> 13.00<kg>
+                | SteelBattleAxe  -> 16.00<kg>
+            member x.Price = 
+                match x with 
+                | RustedAxe        ->  125<usd>
+                | IronAxe          ->  280<usd>
+                | RustedBattleAxe  ->  150<usd>
+                | IronBattleAxe    ->  300<usd>
+                | SteelBattleAxe   ->  425<usd>
+
+            member x.WeaponStats = 
+                match x with 
+                | RustedAxe ->          { Damage = 7.20<dmg>; Defense = 2.10<def>; Speed = -1.00<spd>;  Intelligence = None ; Critical =0.03<ctr> ; HitLimit =   20<hl>; Rank = RankE }
+                | IronAxe ->            { Damage = 11.80<dmg>; Defense = 2.90<def>; Speed = -1.50<spd>; Intelligence = None ; Critical = 0.06<ctr> ;  HitLimit = 25<hl>; Rank = RankD }
+                | RustedBattleAxe ->    { Damage = 7.10<dmg>; Defense = 2.30<def>; Speed = -1.20<spd>; Intelligence = None ; Critical = 0.04<ctr> ; HitLimit =  20<hl>; Rank = RankE }
+                | IronBattleAxe ->      { Damage = 12.00<dmg>; Defense = 3.05<def>; Speed = -1.60<spd>;Intelligence = None ; Critical = 0.07<ctr> ; HitLimit =  25<hl>; Rank = RankD }
+                | SteelBattleAxe ->     { Damage = 16.20<dmg>; Defense = 3.50<def>; Speed = -2.60<spd>;Intelligence = None ; Critical = 0.095<ctr> ; HitLimit =  30<hl>; Rank = RankC }
+
+        type Spear =
+            | RustedSpear
+            | IronSpear  
+            | SteelSpear 
+        with
+            override x.ToString() = 
+                match x with 
+                | RustedSpear -> "Rusted spear"
+                | IronSpear -> "Iron spear"
+                | SteelSpear -> "Steel spear"
+            member x.WeaponStats = 
+                match x with
+                | RustedSpear  -> { Damage = 8.20<dmg>; Intelligence = None; Defense = -3.30<def>; Speed = -1.10<spd>; Critical = 0.05<ctr>; HitLimit = 12<hl>; Rank = RankE }
+                | IronSpear    -> { Damage = 12.00<dmg>; Intelligence = None; Defense = -4.25<def>; Speed = -1.50<spd>; Critical = 0.075<ctr>; HitLimit = 15<hl>; Rank = RankD }
+                | SteelSpear   -> { Damage = 14.75<dmg>; Intelligence = None; Defense = -5.05<def>; Speed = -1.75<spd>; Critical = 0.0925<ctr>; HitLimit = 20<hl>; Rank = RankC }               
+            member x.Weight = 
+                match x with 
+                | RustedSpear -> 15.0<kg>
+                | IronSpear   -> 20.0<kg>
+                | SteelSpear  -> 30.0<kg>
+            member x.Price = 
+                match x with
+                | RustedSpear  -> 200<usd>
+                | IronSpear    -> 325<usd>
+                | SteelSpear   -> 550<usd>          
+
+        type Staff = 
+            | RookieStaff       
+            | AdeptStaff        
+            | SorcererStaff     
+            | NecromancerStaff  
+        with
+            override x.ToString() = 
+                match x with 
+                | RookieStaff -> "Rookie staff"
+                | AdeptStaff -> "Adept staff"
+                | SorcererStaff -> "Sorcerer staff"
+                | NecromancerStaff  -> "Necromancer staff"
+            member x.WeaponStats = 
+                match x with
+                | RookieStaff       ->  { Damage = 3.00<dmg>; Defense = 1.50<def>; Intelligence = Some 4.00<intel>; Speed = 1.00<spd>; Critical = 0.02<ctr>; HitLimit= 10<hl>; Rank = RankE }
+                | AdeptStaff        ->{ Damage = 5.00<dmg>; Defense = 2.00<def>; Intelligence = Some 7.00<intel>; Speed = 0.80<spd>; Critical = 0.045<ctr>; HitLimit= 12<hl>; Rank = RankD }
+                | SorcererStaff     ->{ Damage = 6.70<dmg>; Defense = 4.50<def>; Intelligence = Some 9.20<intel>; Speed = 1.10<spd>; Critical = 0.075<ctr>; HitLimit = 20<hl>; Rank = RankC }
+                | NecromancerStaff  ->{ Damage = 8.00<dmg>; Defense = 5.00<def>; Intelligence = Some 13.00<intel>; Speed = 1.00<spd>; Critical = 0.00<ctr>; HitLimit = 25<hl>; Rank = RankA }
+            member x.Weight = 
+                match x with 
+                | RookieStaff       -> 2.20<kg>
+                | AdeptStaff        -> 4.20<kg>
+                | SorcererStaff     -> 5.10<kg>
+                | NecromancerStaff  -> 3.20<kg>
+            member x.Price =
+                match x with
+                | RookieStaff      -> 180<usd>
+                | AdeptStaff       -> 270<usd>
+                | SorcererStaff    -> 445<usd>
+                | NecromancerStaff -> 650<usd>
+
+        type Blade = 
+            | RustedLongBlade
+            | RustedKatana   
+            | IronLongBlade  
+            | CurvedLongBlade
+            | SteelKatana    
+            | SteelLongBlade 
+        with
+            override x.ToString() = 
+                match x with 
+                | RustedLongBlade -> "Rusted long blade"
+                | RustedKatana    -> "Rusted katana"
+                | IronLongBlade   -> "Iron long blade" 
+                | CurvedLongBlade  -> "Curved long blade"
+                | SteelKatana     -> "Steel katana"
+                | SteelLongBlade  -> "Steel long blade"       
+            member x.WeaponStats = 
+                match x with
+                | RustedLongBlade -> { Damage = 6.00<dmg>; Defense = 0.5<def>; Intelligence = None; Speed = 1.10<spd>; Critical = 0.01<ctr>; HitLimit = 10<hl>; Rank = RankE }
+                | RustedKatana    -> { Damage = 5.50<dmg>; Defense = 0.45<def>; Intelligence = None; Speed = 1.07<spd>; Critical = 0.02<ctr>; HitLimit = 10<hl>; Rank = RankE }
+                | IronLongBlade   -> { Damage = 8.50<dmg>; Defense = 0.65<def>; Intelligence = None; Speed = 1.20<spd>; Critical = 0.03<ctr>; HitLimit = 10<hl>; Rank = RankD }
+                | CurvedLongBlade -> { Damage = 7.00<dmg>; Defense = 0.80<def>; Intelligence = None; Speed = 1.25<spd>; Critical = 0.055<ctr>; HitLimit = 10<hl>; Rank = RankD }
+                | SteelKatana     -> { Damage = 13.0<dmg>; Defense = 1.00<def>; Intelligence = None; Speed = 1.60<spd>; Critical = 0.07<ctr>; HitLimit = 15<hl>; Rank = RankC }
+                | SteelLongBlade  -> { Damage = 15.00<dmg>; Defense = 1.10<def>; Intelligence = None; Speed = 1.55<spd>; Critical = 0.085<ctr>; HitLimit = 15<hl>; Rank = RankC }
+            member x.Weight = 
+                match x with 
+                | RustedLongBlade -> 6.00<kg>
+                | RustedKatana    -> 7.75<kg>
+                | IronLongBlade   -> 14.25<kg>
+                | CurvedLongBlade -> 11.20<kg>
+                | SteelKatana     -> 16.78<kg>
+                | SteelLongBlade  -> 15.30<kg>
+            member x.Price = 
+                match x with 
+                | RustedLongBlade ->  120<usd>
+                | RustedKatana    ->  100<usd>
+                | IronLongBlade   ->  215<usd>
+                | CurvedLongBlade ->  240<usd>
+                | SteelKatana     ->  350<usd>
+                | SteelLongBlade  ->  410<usd> 
+
+        type SpellbookStats = {
+            AttackRange : int 
+            Damage      : float<dmg> 
+            Rank        : WeaponRank
+            Uses        : int
+            ManaCost    : float<mp>
+        }
+        with
+            interface IStats with 
+                member x.showStat() = 
+                    sprintf "Damage : %O - Attack range : %O - Mana cost: %O - Number of use: %O - Rank of spell: %O" x.Damage x.AttackRange x.ManaCost x.Uses x.Rank
+
+        type Spellbook =
+            | Fireball       
+            | Thunder       
+            | Frost         
+            | Hellfire      
+            | BlackFire     
+            | StormOfBlades 
+        with
+            override x.ToString() =     
+                match x with 
+                | Fireball -> "Fireball" 
+                | Thunder -> "Thunder"
+                | Frost -> "Frost" 
+                | Hellfire -> "Hellfire"
+                | BlackFire -> "Black fire" 
+                | StormOfBlades -> "Storm of blades"
+            member x.SpellStats =
+                match x with
+                | Fireball         -> { Damage = 8.0<dmg>; AttackRange = 1; Rank = RankE; Uses = 30 ; ManaCost = 12.0<mp> }
+                | Thunder          -> { Damage = 8.0<dmg>; AttackRange = 1; Rank = RankE; Uses = 30 ; ManaCost = 12.0<mp> }
+                | Frost            -> { Damage = 8.0<dmg>; AttackRange = 1; Rank = RankE; Uses = 30 ; ManaCost = 12.0<mp> }
+                | Hellfire         -> { Damage = 6.50<dmg>; AttackRange = 2; Rank = RankD; Uses = 25; ManaCost = 20.0<mp> }
+                | BlackFire        -> { Damage = 11.2<dmg>; AttackRange = 2; Rank = RankC; Uses = 20; ManaCost = 25.0<mp> }
+                | StormOfBlades    -> { Damage = 5.80<dmg>; AttackRange = 3; Rank = RankD; Uses = 30; ManaCost = 22.0<mp> }    
+            member x.Weight =
+                match x with
+                | Fireball         -> 0.05<kg>
+                | Thunder          -> 0.05<kg>
+                | Frost            -> 0.05<kg>
+                | Hellfire         -> 0.05<kg>
+                | BlackFire        -> 0.05<kg>
+                | StormOfBlades    -> 0.05<kg>
+            member x.Price =
+                match x with
+                | Fireball        -> 150<usd>
+                | Thunder         -> 150<usd>
+                | Frost           -> 150<usd>
+                | Hellfire        -> 350<usd>
+                | BlackFire       -> 350<usd>
+                | StormOfBlades   -> 350<usd>
+
+        type Weaponry = 
+            | Dagger        of Dagger 
+            | Sword         of Sword 
+            | Axe           of Axe
+            | Spear         of Spear
+            | Staff         of Staff 
+            | LongBlade     of Blade
+            | Spellbook     of Spellbook
+        with 
+            member x.Name = 
+                match x with 
+                | Dagger d -> d.ToString() 
+                | Sword  s -> s.ToString() 
+                | Axe    a -> a.ToString() 
+                | Spear  s -> s.ToString() 
+                | Staff  s -> s.ToString()
+                | LongBlade lb -> lb.ToString() 
+                | Spellbook sb -> sb.ToString()
+            member x.Price = 
+                match x with 
+                | Dagger     w -> w.Price
+                | Sword      w -> w.Price
+                | Axe        w -> w.Price
+                | Spear      w -> w.Price
+                | Staff      w -> w.Price
+                | LongBlade  w -> w.Price
+                | Spellbook  w -> w.Price
+            member x.Weight =
+                match x with
+                | Dagger     w -> w.Weight
+                | Sword      w -> w.Weight
+                | Axe        w -> w.Weight
+                | Spear      w -> w.Weight
+                | Staff      w -> w.Weight
+                | LongBlade  w -> w.Weight
+                | Spellbook  w -> w.Weight
+
+            member x.Stats = 
+                match x with
+                | Dagger     w -> w.WeaponStats :> IStats
+                | Sword      w -> w.WeaponStats :> IStats
+                | Axe        w -> w.WeaponStats :> IStats
+                | Spear      w -> w.WeaponStats :> IStats
+                | Staff      w -> w.WeaponStats :> IStats
+                | LongBlade  w -> w.WeaponStats :> IStats
+                | Spellbook  w -> w.SpellStats  :> IStats
+        let computeCharacterOverallOffensive
+            (rank: WeaponRank)
+            (weapon: Weaponry)
+            (cStats: CharacterStats) = 
+            let strength = 
+                cStats.Strength *
+                    match rank with 
+                    | RankE -> 1.0100
+                    | RankD -> 1.0375
+                    | RankC -> 1.0925
+                    | RankB -> 1.1250
+                    | RankA -> 1.1785
+                    | RankS -> 1.2105
+
+            let overallDamage = 
+                strength *
+                    match weapon with 
+                    | Dagger d -> 
+                        d.WeaponStats.Damage 
+                    | Sword s -> 
+                        s.WeaponStats.Damage 
+                    | Axe a -> 
+                        a.WeaponStats.Damage
+                    | Spear s -> 
+                        s.WeaponStats.Damage 
+                    | Staff s -> 
+                        s.WeaponStats.Damage 
+                    | LongBlade lb -> 
+                        lb.WeaponStats.Damage 
+                    | Spellbook sb -> 
+                        sb.SpellStats.Damage 
+            overallDamage
+
+    [<AutoOpen>]
+    module CharacterWearableProtection =
+        
+        type CharacterProtectionStats = {
+            Defense : float<def>
+            Resistance : float<res>
+            Intelligence : float<intel> option
+            MagicResist : float<mgres>
+            Speed  : float<spd>
+            EquipmentUsage : int<eu>
+        }
+        with 
+            interface IStats with 
+                member x.showStat() = 
+                    sprintf "Defense : %O - Resistance : %O - Magic resistance : %O - Speed : %O - Equipment usage : %O" x.Defense x.Resistance x.MagicResist x.Speed x.EquipmentUsage
+        
+        type Hat = 
+            | SorcererHat 
+            | InfantryHat 
+            | JourneyManHelmet  
+            | RustedHelmet 
+            | MerlinsHat 
+            | IronHelmet 
+            | SteelHelmet 
+        with 
+            override x.ToString() = 
+                match x with 
+                | SorcererHat -> "Sorcerer hat"
+                | InfantryHat -> "Infantry hat"
+                | JourneyManHelmet -> "Journey man helmet"
+                | RustedHelmet -> "Rusted helmet"
+                | MerlinsHat -> "Merlin's hat"
+                | IronHelmet -> "Iron helmet"
+                | SteelHelmet -> "Steel helmet"
+            member x.Name = 
+                match x with 
+                | _ -> x.ToString()
+            
+            member x.Weight = 
+                match x with 
+                | SorcererHat -> 1.0<kg>
+                | InfantryHat -> 3.20<kg>
+                | JourneyManHelmet -> 2.25<kg>
+                | RustedHelmet -> 2.50<kg>
+                | MerlinsHat -> 4.10<kg>
+                | IronHelmet -> 6.25<kg>
+                | SteelHelmet -> 8.00<kg>
+
+            member x.CharacterProtectionStats = 
+                match x with 
+                | SorcererHat       -> { Defense = 1.20<def>; Resistance = 1.30<res>; Intelligence = Some 3.00<intel>; MagicResist = 1.80<mgres>; Speed = 1.00<spd>; EquipmentUsage = 100<eu> }
+                | InfantryHat  -> { Defense = 2.20<def>; Resistance = 1.80<res>; Intelligence = None; MagicResist = 0.80<mgres>; Speed = 0.95<spd>; EquipmentUsage = 100<eu> }
+                | JourneyManHelmet -> { Defense = 5.60<def>; Resistance = 3.20<res>; Intelligence = None; MagicResist = 0.60<mgres>; Speed = 0.90<spd>; EquipmentUsage = 100<eu> }
+                | RustedHelmet -> { Defense = 4.80<def>; Resistance = 2.70<res>; Intelligence = None; MagicResist = 0.20<mgres>; Speed = 1.00<spd>; EquipmentUsage = 75<eu> }
+                | MerlinsHat -> { Defense = 3.10<def>; Resistance = 1.70<res>; Intelligence = Some 6.50<intel>; MagicResist = 3.45<mgres>; Speed = 1.03<spd>; EquipmentUsage = 100<eu> }
+                | IronHelmet -> { Defense = 7.20<def>; Resistance = 3.50<res>; Intelligence = None; MagicResist = 0.40<mgres>; Speed = 0.98<spd>; EquipmentUsage = 100<eu> }
+                | SteelHelmet -> { Defense = 10.80<def>; Resistance = 4.20<res>; Intelligence = None; MagicResist = 0.40<mgres>; Speed = 0.95<spd>; EquipmentUsage = 100<eu> }
+
+        type Armor = 
+            | InfantryArmor 
+            | RustedArmor 
+            | IronArmor 
+            | SteelArmor 
+            | MyrtilleArmor
+        with 
+            override x.ToString() = 
+                match x with 
+                | InfantryArmor -> "Infantry armor" 
+                | RustedArmor -> "Rusted armor"
+                | IronArmor   -> "Iron armor"
+                | SteelArmor  -> "Steel armor"
+                | MyrtilleArmor -> "Myrtille armor"
+            
+            member x.Weight = 
+                match x with 
+                | InfantryArmor  -> 6.0<kg>
+                | RustedArmor    -> 5.5<kg> 
+                | IronArmor      -> 10.0<kg> 
+                | SteelArmor     -> 15.0<kg>
+                | MyrtilleArmor  -> 22.75<kg> 
+            member x.Name = 
+                match x with 
+                | _ -> x.ToString()
+
+            member x.CharacterProtectionStats = 
+                match x with 
+                | InfantryArmor -> { Defense = 6.50<def>; Resistance = 2.20<res>; Intelligence = None; MagicResist = 0.00<mgres>; Speed = 0.99<spd>; EquipmentUsage = 100<eu> }
+                | RustedArmor   -> { Defense = 4.20<def>; Resistance = 1.10<res>; Intelligence = None; MagicResist = 0.30<mgres>; Speed = 1.00<spd>; EquipmentUsage = 50<eu> }
+                | IronArmor     -> { Defense = 12.00<def>; Resistance = 4.30<res>; Intelligence = None; MagicResist = 1.00<mgres>; Speed = 0.975<spd>; EquipmentUsage = 100<eu> }
+                | SteelArmor    -> { Defense = 17.40<def>; Resistance = 6.10<res>; Intelligence = None; MagicResist = 2.30<mgres>; Speed = 0.945<spd>; EquipmentUsage = 100<eu> }
+                | MyrtilleArmor -> { Defense = 23.55<def>; Resistance = 10.10<res>; Intelligence = None; MagicResist = 5.70<mgres>; Speed = 0.9725<spd>; EquipmentUsage = 100<eu> }
+            
+        type Pants = 
+            | InfantryPants 
+            | IronPants 
+            | SteelPants 
+            | MyrtillePants 
+        with 
+            override x.ToString() = 
+                match x with 
+                | InfantryPants -> "Infantry pants" 
+                | IronPants -> "Iron pants" 
+                | SteelPants -> "Steel pants" 
+                | MyrtillePants -> "Myrtille pants" 
+
+            member x.Name :string=     
+                match x with 
+                | _ -> x.ToString()
+
+            member x.Weight = 
+                match x with 
+                | InfantryPants -> 4.00<kg>
+                | IronPants -> 5.75<kg> 
+                | SteelPants -> 10.80<kg> 
+                | MyrtillePants -> 15.20<kg> 
+
+            member x.CharacterProtectionStats = 
+                match x with 
+                | InfantryPants -> 
+                    { Defense = 0.85<def>; Resistance = 0.30<res>; Intelligence = None; MagicResist = 0.00<mgres>; Speed = 0.99<spd>; EquipmentUsage = 100<eu> }
+                | IronPants -> { Defense = 3.50<def>; Resistance = 1.20<res>; Intelligence = None; MagicResist = 0.50<mgres>; Speed = 0.98<spd>; EquipmentUsage = 100<eu> }
+                | SteelPants -> { Defense = 5.10<def>; Resistance = 2.00<res>; Intelligence = None; MagicResist = 1.00<mgres>; Speed = 0.95<spd>; EquipmentUsage = 100<eu> }
+                | MyrtillePants -> { Defense = 6.50<def>; Resistance = 2.70<res>; Intelligence = None; MagicResist = 3.00<mgres>; Speed = 0.9765<spd>; EquipmentUsage = 100<eu> }
+
+        type Gauntlets = 
+            | InfantryGauntless 
+            | RustedGauntless 
+            | IronGauntless 
+            | SteelGauntless 
+        with 
+            override x.ToString() = 
+                match x with 
+                | InfantryGauntless -> "Infantry gauntlets"
+                | RustedGauntless -> "Rusted gauntlets"
+                | IronGauntless -> "Iron gauntlets"
+                | SteelGauntless -> "Steel gauntlets"
+            member x.Name = 
+                match x with 
+                | _ -> x.ToString()
+            member x.Weight = 
+                match x with 
+                | InfantryGauntless -> 1.00<kg>
+                | RustedGauntless -> 1.70<kg> 
+                | IronGauntless -> 3.20<kg> 
+                | SteelGauntless -> 6.55<kg>
+            member x.CharacterProtectionStats = 
+                match x with 
+                | InfantryGauntless -> 
+                    { Defense = 0.85<def>; Resistance = 0.15<res>; Intelligence = None; MagicResist = 0.10<mgres>; Speed = 0.995<spd>; EquipmentUsage = 100<eu> }
+                | RustedGauntless -> 
+                    { Defense = 1.2<def>; Resistance = 0.45<res>; Intelligence = None; MagicResist = 0.20<mgres>; Speed = 0.99<spd>; EquipmentUsage = 50<eu> }
+                | IronGauntless -> 
+                    { Defense = 3.65<def>; Resistance = 0.85<res>; Intelligence = None; MagicResist = 0.25<mgres>; Speed = 0.975<spd>; EquipmentUsage = 100<eu> }
+                | SteelGauntless -> 
+                    { Defense = 5.15<def>; Resistance = 1.35<res>; Intelligence = None; MagicResist = 0.45<mgres>; Speed = 0.95<spd>; EquipmentUsage = 100<eu> }
+
+        type RingStats = {
+            ExtraStrength : float<str> option
+            ExtraDamage   : float<dmg> option 
+            ExtraHealth   : float<hp> option
+            ExtraMana     : float<mp> option
+        }
+        with
+            interface IStats with 
+                member x.showStat() = 
+                    sprintf ""
+            static member Initial = 
+                { ExtraDamage = None; ExtraStrength = None; ExtraHealth = None; ExtraMana = None }
+
+        type Ring = 
+            | ExtraStrenghtRing 
+            | ExtraDamageRing 
+            | ExtraHealthRing 
+            | ExtraManaRing  
+        with 
+            override x.ToString() =     
+                match x with 
+                | ExtraStrenghtRing -> "Extra strenght ring"
+                | ExtraDamageRing -> "Extra damage ring"
+                | ExtraHealthRing -> "Extra health ring"
+                | ExtraManaRing -> "Extra mana ring"
+
+            member x.Name = 
+                match x with 
+                | _ -> x.ToString() 
+
+            member x.Weight : float<kg> = 
+                match x with 
+                | _ -> 0.75<kg> 
+
+            member x.CharacterProtectionStat = 
+                match x with 
+                | ExtraDamageRing ->  { RingStats.Initial with ExtraDamage = Some 5.00<dmg> }
+                | ExtraStrenghtRing -> { RingStats.Initial with ExtraStrength = Some 4.50<str> }
+                | ExtraHealthRing -> { RingStats.Initial with ExtraHealth = Some 12.00<hp> }
+                | ExtraManaRing -> { RingStats.Initial with ExtraMana = Some 7.00<mp> }
+
+        type ShieldStats = {
+            Defense : float<def> 
+            Resistance :float<res> 
+            Speed   : float<spd> 
+            MagicResist : float<mgres>
+            ShieldRank  : WeaponRank
+            EquipmentUsage : int<eu>
+        }
+        with
+            interface IStats with 
+                member x.showStat() = 
+                    sprintf "Defense : %O - Resistance : %O - Magic resistance : %O - Equipment usage : %O" x.Defense x.Resistance x.MagicResist x.EquipmentUsage
+
+        type Shield = 
+            | RustedShield 
+            | SmallShield 
+            | KnightShield 
+            | HeavyShield 
+            | SteelShield 
+        with 
+            override x.ToString()  = 
+                match x with 
+                | RustedShield -> "Rusted shield" 
+                | SmallShield -> "Small shield" 
+                | KnightShield -> "Knight shield" 
+                | HeavyShield -> "Heavy shield" 
+                | SteelShield -> "Steel shield" 
+
+            member x.Name = 
+                 match x with 
+                 | _ -> x.ToString()             
+            member x.Weight = 
+                match x with 
+                | RustedShield -> 5.00<kg> 
+                | SmallShield -> 3.25<kg> 
+                | KnightShield -> 6.80<kg> 
+                | HeavyShield -> 12.50<kg> 
+                | SteelShield -> 10.80<kg> 
+
+            member x.CharacterProtectionStat = 
+                match x with 
+                | RustedShield -> 
+                    { Defense = 5.60<def>; Resistance = 3.10<res>; Speed = 0.96<spd>; MagicResist = 1.85<mgres>; ShieldRank = RankE; EquipmentUsage = 50<eu> } 
+                | SmallShield -> 
+                    { Defense = 3.80<def>; Resistance = 2.70<res>; Speed = 0.985<spd>; MagicResist = 0.50<mgres>; ShieldRank = RankE; EquipmentUsage = 100<eu> } 
+                | KnightShield -> 
+                    { Defense = 9.80<def>; Resistance = 5.10<res>; Speed = 0.94<spd>; MagicResist = 3.40<mgres>; ShieldRank = RankC; EquipmentUsage = 100<eu> } 
+                | HeavyShield -> 
+                    { Defense = 12.75<def>; Resistance = 6.40<res>; Speed = 0.88<spd>; MagicResist = 4.60<mgres>; ShieldRank = RankC; EquipmentUsage = 100<eu> } 
+                | SteelShield -> 
+                    { Defense = 17.20<def>; Resistance = 9.30<res>; Speed = 0.93<spd>; MagicResist = 5.90<mgres>; ShieldRank = RankB; EquipmentUsage = 100<eu> } 
+
+        type CharacterProtection = 
+            | Shield        of Shield 
+            | Ring          of Ring 
+            | Gloves        of Gauntlets 
+            | Legs          of Pants
+            | Armor         of Armor 
+            | Hat           of Hat 
+
+        with 
+            member x.Name = 
+                match x with 
+                | Shield s -> s.Name 
+                | Ring r -> r.Name 
+                | Gloves g -> g.Name 
+                | Legs l -> l.Name 
+                | Armor a -> a.Name 
+                | Hat h -> h.Name 
+            
+            member x.Weight = 
+                match x with
+                | Shield s -> s.Weight 
+                | Ring r -> r.Weight 
+                | Gloves g -> g.Weight 
+                | Legs l -> l.Weight 
+                | Armor a -> a.Weight 
+                | Hat h -> h.Weight 
+
+            member x.ProtectionStats = 
+                match x with 
+                | Shield s -> s.CharacterProtectionStat :> IStats
+                | Ring r -> r.CharacterProtectionStat :> IStats
+                | Gloves g -> g.CharacterProtectionStats :> IStats
+                | Legs l -> l.CharacterProtectionStats :> IStats
+                | Armor a -> a.CharacterProtectionStats :> IStats
+                | Hat h -> h.CharacterProtectionStats   :> IStats           
+
+    [<AutoOpen>]
+    module Inventory =
+
+        type GameItem = 
+            | Consummable   of ConsummableItem * int 
+            | Weapon        of Weaponry * int
+            | Protection    of CharacterProtection * int
+        with 
+            member x.UpdateQuantity value variationProvenance = 
+                let itemVariation = 
+                    match variationProvenance with 
+                    | FromTheShop -> value 
+                    | FromTheInventory -> value * -1
+
+                let qty = x.Quantity + itemVariation
+                let qty=
+                    match qty with 
+                    | t when t > 99 -> 99
+                    | t when t <0 -> 0
+                    | _ -> qty
+                qty  
+
+        let makeBagItemsDistinct (bag: GameItem array) = 
+            bag |> Seq.distinct |> Seq.toArray
+        
+        type Inventory = {
+            Bag : GameItem array
+            Weight: float<kg>
+        }
+        with 
+            member x.filterFromLightestToHeaviest() =
+                x.Bag |> Array.sortBy(fun item -> item.ItemWeight)
+
+            member x.filterFromHeaviestToLightest() = 
+                x.Bag  |> Array.sortBy (fun x -> -x.ItemWeight - 1.0<kg>) // Sort in a descending order
+
+            member x.addItem (ii: InventoryItem): Inventory = 
+                if x.Weight >= MaxWeight <> true then x 
+                elif (x.Weight + ii.ItemWeight) >= MaxWeight then x
                 else 
-                    { characterStat with 
-                        Health = (characterStat.Health :> IEnergyPoint).raisePoints ((removeUnitFromFloat characterStat.Health.MaxLife) * 0.50) :?> HealthPoint
-                        Mana = (characterStat.Mana :> IEnergyPoint).raisePoints ((removeUnitFromFloat characterStat.Mana.MaxMana) * 0.50) :?> ManaPoint
-                    }
+                    let oItemIndex = x.Bag |> Array.tryFindIndex(fun x -> x = ii)
+                    match oItemIndex with 
+                    | Some index -> 
+                        // There already an item of this type in the bag
+                        let item = x.Bag |> Array.find(fun x -> x = ii)
+                        let newBag = 
+                            x.Bag
+                            |> Array.filter((<>) item)
+                            |> Array.append 
+                                [| 
+                                    { item with Quantity = item.Quantity + ii.Quantity }
+                                |]
+                            |> makeBagItemsDistinct
 
-            | MedicinalHerb ->  { characterStat with Health = (characterStat.Health :> IEnergyPoint).raisePoints 5.0 :?> HealthPoint }
-            
-    type Dagger = 
-        | RustedDagger 
-        | IronDagger   
-        | SteelDagger  
-    with   
-        override x.ToString() = 
-            match x with 
-            | RustedDagger  -> "Rusted dagger"
-            | IronDagger    -> "Iron dagger"
-            | SteelDagger   -> "Steel dagger"
-        member x.WeaponStats = 
-            match x with
-            | RustedDagger -> { Damage = 5.60<dmg>; Defense = 1.20<def>; Intelligence = None; Speed = 1.00<spd>; Critical = 0.02<ctr>; HitLimit = 20<hl>; Rank = RankE }
-            | IronDagger   -> { Damage = 9.80<dmg>; Defense = 2.30<def>; Intelligence = None; Speed = 1.10<spd>; Critical = 0.04<ctr>; HitLimit = 25<hl>; Rank = RankD }
-            | SteelDagger  -> { Damage = 13.10<dmg>; Defense = 3.00<def>; Intelligence = None; Speed = 1.15<spd>; Critical = 0.05<ctr>; HitLimit = 30<hl>; Rank = RankC }
-            
-        member x.Weight = 
-            match x with 
-            | RustedDagger -> 2.10<kg>
-            | IronDagger   -> 2.80<kg>
-            | SteelDagger  -> 4.25<kg>
-            
-        member x.Price = 
-             match x with 
-             | RustedDagger -> 80<usd> 
-             | IronDagger   -> 200<usd> 
-             | SteelDagger  -> 350<usd>   
+                        let inventory = { x with Bag = newBag }
+                        { inventory with Weight = inventory.Weight + item.ItemWeight }
+                    | None -> 
+                        let newBag = x.Bag |> Array.append [|ii|] |> makeBagItemsDistinct
+                        let inventory = { x with Bag = newBag }
+                        { inventory with Weight = inventory.Weight + ii.ItemWeight }
 
-    type Sword = 
-        | BrokenSword 
-        | RustedSword 
-        | IronSword   
-        | SteelSword  
-    with
-        override x.ToString() = 
-            match x with 
-            | BrokenSword -> "Broken sword"
-            | RustedSword -> "Rusted sword"
-            | IronSword   -> "Iron sword"
-            | SteelSword  -> "Steel sword`"
-        member x.WeaponStats = 
-            match x with
-            | BrokenSword -> { Damage = 5.4<dmg>; Defense = 2.50<def>; Intelligence = None; Speed = 1.2<spd>; Critical = 0.01<ctr>; HitLimit = 10<hl>; Rank = RankE }
-            | RustedSword -> { Damage = 8.75<dmg>; Defense = 2.90<def>; Intelligence = None ;Speed = 1.05<spd>; Critical = 0.03<ctr>; HitLimit = 20<hl>; Rank = RankD }
-            | IronSword   -> { Damage = 11.1<dmg>; Defense = 3.40<def>; Intelligence = None ;Speed = 1.00<spd>; Critical = 0.04<ctr>; HitLimit = 25<hl>; Rank = RankC }
-            | SteelSword  -> { Damage = 15.25<dmg>; Defense = 4.30<def>;Intelligence = None ; Speed = 0.85<spd>; Critical = 0.06<ctr>; HitLimit = 35<hl>; Rank = RankB }
-        member x.Weight = 
-            match x with 
-            | BrokenSword  -> 7.20<kg>
-            | RustedSword  -> 8.50<kg>
-            | IronSword    -> 12.35<kg>
-            | SteelSword   -> 15.00<kg>
+            member x.addItems (iiArr: InventoryItem array) = 
+                let newBag = x.Bag |> Array.append iiArr |> makeBagItemsDistinct
+                let inventory = { x with Bag = newBag }
 
-        member x.Price = 
-             match x with 
-             | BrokenSword  -> 90<usd>
-             | RustedSword  -> 120<usd>
-             | IronSword    -> 250<usd>
-             | SteelSword   -> 525<usd>
+                { inventory with Weight = inventory.Weight + 0.0<kg> }
 
-    type Axe = 
-        | RustedAxe        
-        | IronAxe         
-        | RustedBattleAxe 
-        | IronBattleAxe   
-        | SteelBattleAxe  
-    with
-        override x.ToString() = 
-            match x with 
-            | RustedAxe -> "Rusted axe"
-            | IronAxe -> "Iron axe"
-            | RustedBattleAxe -> "Rusted battle axe"
-            | IronBattleAxe -> "Iron battle axe"
-            | SteelBattleAxe -> "SteelBattleAxe"
-
-        member x.Weight =
-            match x with 
-            | RustedAxe       -> 8.00<kg>
-            | IronAxe         -> 10.00<kg>
-            | RustedBattleAxe -> 9.00<kg>
-            | IronBattleAxe   -> 13.00<kg>
-            | SteelBattleAxe  -> 16.00<kg>
-        member x.Price = 
-             match x with 
-             | RustedAxe        ->  125<usd>
-             | IronAxe          ->  280<usd>
-             | RustedBattleAxe  ->  150<usd>
-             | IronBattleAxe    ->  300<usd>
-             | SteelBattleAxe   ->  425<usd>
-
-        member x.WeaponStats = 
-            match x with 
-            | RustedAxe ->          { Damage = 7.20<dmg>; Defense = 2.10<def>; Speed = -1.00<spd>;  Intelligence = None ; Critical =0.03<ctr> ; HitLimit =   20<hl>; Rank = RankE }
-            | IronAxe ->            { Damage = 11.80<dmg>; Defense = 2.90<def>; Speed = -1.50<spd>; Intelligence = None ; Critical = 0.06<ctr> ;  HitLimit = 25<hl>; Rank = RankD }
-            | RustedBattleAxe ->    { Damage = 7.10<dmg>; Defense = 2.30<def>; Speed = -1.20<spd>; Intelligence = None ; Critical = 0.04<ctr> ; HitLimit =  20<hl>; Rank = RankE }
-            | IronBattleAxe ->      { Damage = 12.00<dmg>; Defense = 3.05<def>; Speed = -1.60<spd>;Intelligence = None ; Critical = 0.07<ctr> ; HitLimit =  25<hl>; Rank = RankD }
-            | SteelBattleAxe ->     { Damage = 16.20<dmg>; Defense = 3.50<def>; Speed = -2.60<spd>;Intelligence = None ; Critical = 0.095<ctr> ; HitLimit =  30<hl>; Rank = RankC }
-
-    type Spear =
-        | RustedSpear
-        | IronSpear  
-        | SteelSpear 
-    with
-        override x.ToString() = 
-            match x with 
-            | RustedSpear -> "Rusted spear"
-            | IronSpear -> "Iron spear"
-            | SteelSpear -> "Steel spear"
-        member x.WeaponStats = 
-            match x with
-            | RustedSpear  -> { Damage = 8.20<dmg>; Intelligence = None; Defense = -3.30<def>; Speed = -1.10<spd>; Critical = 0.05<ctr>; HitLimit = 12<hl>; Rank = RankE }
-            | IronSpear    -> { Damage = 12.00<dmg>; Intelligence = None; Defense = -4.25<def>; Speed = -1.50<spd>; Critical = 0.075<ctr>; HitLimit = 15<hl>; Rank = RankD }
-            | SteelSpear   -> { Damage = 14.75<dmg>; Intelligence = None; Defense = -5.05<def>; Speed = -1.75<spd>; Critical = 0.0925<ctr>; HitLimit = 20<hl>; Rank = RankC }               
-        member x.Weight = 
-            match x with 
-            | RustedSpear -> 15.0<kg>
-            | IronSpear   -> 20.0<kg>
-            | SteelSpear  -> 30.0<kg>
-        member x.Price = 
-             match x with
-             | RustedSpear  -> 200<usd>
-             | IronSpear    -> 325<usd>
-             | SteelSpear   -> 550<usd>          
-
-    type Staff = 
-        | RookieStaff       
-        | AdeptStaff        
-        | SorcererStaff     
-        | NecromancerStaff  
-    with
-        override x.ToString() = 
-            match x with 
-            | RookieStaff -> "Rookie staff"
-            | AdeptStaff -> "Adept staff"
-            | SorcererStaff -> "Sorcerer staff"
-            | NecromancerStaff  -> "Necromancer staff"
-        member x.WeaponStats = 
-            match x with
-            | RookieStaff       ->  { Damage = 3.00<dmg>; Defense = 1.50<def>; Intelligence = Some 4.00<intel>; Speed = 1.00<spd>; Critical = 0.02<ctr>; HitLimit= 10<hl>; Rank = RankE }
-            | AdeptStaff        ->{ Damage = 5.00<dmg>; Defense = 2.00<def>; Intelligence = Some 7.00<intel>; Speed = 0.80<spd>; Critical = 0.045<ctr>; HitLimit= 12<hl>; Rank = RankD }
-            | SorcererStaff     ->{ Damage = 6.70<dmg>; Defense = 4.50<def>; Intelligence = Some 9.20<intel>; Speed = 1.10<spd>; Critical = 0.075<ctr>; HitLimit = 20<hl>; Rank = RankC }
-            | NecromancerStaff  ->{ Damage = 8.00<dmg>; Defense = 5.00<def>; Intelligence = Some 13.00<intel>; Speed = 1.00<spd>; Critical = 0.00<ctr>; HitLimit = 25<hl>; Rank = RankA }
-        member x.Weight = 
-            match x with 
-            | RookieStaff       -> 2.20<kg>
-            | AdeptStaff        -> 4.20<kg>
-            | SorcererStaff     -> 5.10<kg>
-            | NecromancerStaff  -> 3.20<kg>
-        member x.Price =
-             match x with
-             | RookieStaff      -> 180<usd>
-             | AdeptStaff       -> 270<usd>
-             | SorcererStaff    -> 445<usd>
-             | NecromancerStaff -> 650<usd>
-
-    type Blade = 
-        | RustedLongBlade
-        | RustedKatana   
-        | IronLongBlade  
-        | CurvedLongBlade
-        | SteelKatana    
-        | SteelLongBlade 
-    with
-        override x.ToString() = 
-            match x with 
-            | RustedLongBlade -> "Rusted long blade"
-            | RustedKatana    -> "Rusted katana"
-            | IronLongBlade   -> "Iron long blade" 
-            | CurvedLongBlade  -> "Curved long blade"
-            | SteelKatana     -> "Steel katana"
-            | SteelLongBlade  -> "Steel long blade"       
-        member x.WeaponStats = 
-            match x with
-            | RustedLongBlade -> { Damage = 6.00<dmg>; Defense = 0.5<def>; Intelligence = None; Speed = 1.10<spd>; Critical = 0.01<ctr>; HitLimit = 10<hl>; Rank = RankE }
-            | RustedKatana    -> { Damage = 5.50<dmg>; Defense = 0.45<def>; Intelligence = None; Speed = 1.07<spd>; Critical = 0.02<ctr>; HitLimit = 10<hl>; Rank = RankE }
-            | IronLongBlade   -> { Damage = 8.50<dmg>; Defense = 0.65<def>; Intelligence = None; Speed = 1.20<spd>; Critical = 0.03<ctr>; HitLimit = 10<hl>; Rank = RankD }
-            | CurvedLongBlade -> { Damage = 7.00<dmg>; Defense = 0.80<def>; Intelligence = None; Speed = 1.25<spd>; Critical = 0.055<ctr>; HitLimit = 10<hl>; Rank = RankD }
-            | SteelKatana     -> { Damage = 13.0<dmg>; Defense = 1.00<def>; Intelligence = None; Speed = 1.60<spd>; Critical = 0.07<ctr>; HitLimit = 15<hl>; Rank = RankC }
-            | SteelLongBlade  -> { Damage = 15.00<dmg>; Defense = 1.10<def>; Intelligence = None; Speed = 1.55<spd>; Critical = 0.085<ctr>; HitLimit = 15<hl>; Rank = RankC }
-        member x.Weight = 
-            match x with 
-            | RustedLongBlade -> 6.00<kg>
-            | RustedKatana    -> 7.75<kg>
-            | IronLongBlade   -> 14.25<kg>
-            | CurvedLongBlade -> 11.20<kg>
-            | SteelKatana     -> 16.78<kg>
-            | SteelLongBlade  -> 15.30<kg>
-        member x.Price = 
-             match x with 
-             | RustedLongBlade ->  120<usd>
-             | RustedKatana    ->  100<usd>
-             | IronLongBlade   ->  215<usd>
-             | CurvedLongBlade ->  240<usd>
-             | SteelKatana     ->  350<usd>
-             | SteelLongBlade  ->  410<usd> 
-
-    type SpellbookStats = {
-        AttackRange : int 
-        Rank        : WeaponRank
-        Uses        : int
-    }
-    with
-        interface IStats with 
-            member x.showStat() = 
-                sprintf "Attack range : %O - Number of use: %O - Rank of spell: %O" x.AttackRange x.Uses x.Rank
-
-    type Spellbook =
-        | Fireball       
-        | Thunder       
-        | Frost         
-        | Hellfire      
-        | BlackFire     
-        | StormOfBlades 
-    with
-        override x.ToString() =     
-            match x with 
-            | Fireball -> "Fireball" 
-            | Thunder -> "Thunder"
-            | Frost -> "Frost" 
-            | Hellfire -> "Hellfire"
-            | BlackFire -> "Black fire" 
-            | StormOfBlades -> "Storm of blades"
-        member x.SpellStats =
-            match x with
-            | Fireball         -> { AttackRange = 1; Rank = RankE; Uses = 30 }
-            | Thunder          -> { AttackRange = 1; Rank = RankE; Uses = 30 }
-            | Frost            -> { AttackRange = 1; Rank = RankE; Uses = 30 }
-            | Hellfire         -> { AttackRange = 2; Rank = RankD; Uses = 25 }
-            | BlackFire        -> { AttackRange = 2; Rank = RankC; Uses = 20 }
-            | StormOfBlades    -> { AttackRange = 3; Rank = RankD; Uses = 30 }    
-        member x.Weight =
-            match x with
-            | Fireball         -> 0.05<kg>
-            | Thunder          -> 0.05<kg>
-            | Frost            -> 0.05<kg>
-            | Hellfire         -> 0.05<kg>
-            | BlackFire        -> 0.05<kg>
-            | StormOfBlades    -> 0.05<kg>
-        member x.Price =
-             match x with
-             | Fireball        -> 150<usd>
-             | Thunder         -> 150<usd>
-             | Frost           -> 150<usd>
-             | Hellfire        -> 350<usd>
-             | BlackFire       -> 350<usd>
-             | StormOfBlades   -> 350<usd>
-
-    type Weaponry = 
-        | Dagger        of Dagger 
-        | Sword         of Sword 
-        | Axe           of Axe
-        | Spear         of Spear
-        | Staff         of Staff 
-        | LongBlade     of Blade
-        | Spellbook     of Spellbook
-    with 
-        member x.Price = 
-            match x with 
-            | Dagger     w -> w.Price
-            | Sword      w -> w.Price
-            | Axe        w -> w.Price
-            | Spear      w -> w.Price
-            | Staff      w -> w.Price
-            | LongBlade  w -> w.Price
-            | Spellbook  w -> w.Price
-        member x.Weight =
-            match x with
-            | Dagger     w -> w.Weight
-            | Sword      w -> w.Weight
-            | Axe        w -> w.Weight
-            | Spear      w -> w.Weight
-            | Staff      w -> w.Weight
-            | LongBlade  w -> w.Weight
-            | Spellbook  w -> w.Weight
-
-        member x.Stats = 
-            match x with
-            | Dagger     w -> w.WeaponStats  :> IStats
-            | Sword      w -> w.WeaponStats :> IStats
-            | Axe        w -> w.WeaponStats :> IStats
-            | Spear      w -> w.WeaponStats :> IStats
-            | Staff      w -> w.WeaponStats :> IStats
-            | LongBlade  w -> w.WeaponStats :> IStats
-            | Spellbook  w -> w.SpellStats :> IStats
-
-    type Hat = 
-        | SorcererHat of InventoryItem 
-        | InfantryHat of InventoryItem 
-        | JourneyManHelmet of InventoryItem 
-        | RustedHelmet of InventoryItem 
-        | MerlinsHat of InventoryItem 
-        | IronHelmet of InventoryItem 
-        | SteelHelmet of InventoryItem 
-
-    type Armor = 
-        | InfantryArmor of InventoryItem 
-        | RustedArmor of InventoryItem 
-        | IronArmor of InventoryItem
-        | SteelArmor of InventoryItem
-        | MyrtilleArmor of InventoryItem
-
-    type Pants = 
-        | InfantryPants of InventoryItem
-        | IronPants of InventoryItem
-        | SteelPants of InventoryItem
-        | MyrtillePants of InventoryItem
-
-    type Gauntlets = 
-        | InfantryGauntless of InventoryItem
-        | RustedGauntless of InventoryItem
-        | IronGauntless of InventoryItem
-        | SteelGauntless of InventoryItem
-
-    type Ring = 
-        | ExtraStrenghtRing of InventoryItem
-        | ExtraDamageRing of InventoryItem
-        | ExtraHeathRing  of InventoryItem
-        | ExtraMana        of InventoryItem
-
-    type Shield = 
-        | RustedShield of InventoryItem
-        | SmallShield of InventoryItem
-        | KnightShield of InventoryItem
-        | HeavyShield of InventoryItem
-        | SteelShield of InventoryItem
-
-    type CharacterProtection = 
-        | Shield        of Shield 
-        | Ring          of Ring 
-        | Gloves        of Gauntlets 
-        | Legs          of Pants
-        | Armor         of Armor 
-        | Hat           of Hat 
-
-    type GameItem = 
-        | Consummable   of ConsummableItem
-        | Weapon        of Weaponry
-        | Protection    of CharacterProtection
-    with 
-        member x.UpdateQuantity value variationProvenance = 
-            let itemVariation = 
-                match variationProvenance with 
-                | FromTheShop -> value 
-                | FromTheInventory -> value * -1
-
-            let qty = x.Quantity + itemVariation
-            let qty=
-                match qty with 
-                | t when t > 99 -> 99
-                | t when t <0 -> 0
-                | _ -> qty
-            qty  
-
-    let makeBagItemsDistinct (bag: GameItem array) = 
-        bag |> Seq.distinct |> Seq.toArray
-    
-    type Inventory = {
-        Bag : GameItem array
-        Weight: float<kg>
-    }
-    with 
-        member x.filterFromLightestToHeaviest() =
-            x.Bag |> Array.sortBy(fun item -> item.ItemWeight)
-
-        member x.filterFromHeaviestToLightest() = 
-            x.Bag  |> Array.sortBy (fun x -> -x.ItemWeight - 1.0<kg>) // Sort in a descending order
-
-        member x.addItem (ii: InventoryItem): Inventory = 
-            if x.Weight >= MaxWeight <> true then x 
-            elif (x.Weight + ii.ItemWeight) >= MaxWeight then x
-            else 
-                let oItemIndex = x.Bag |> Array.tryFindIndex(fun x -> x = ii)
-                match oItemIndex with 
-                | Some index -> 
-                    // There already an item of this type in the bag
-                    let item = x.Bag |> Array.find(fun x -> x = ii)
-                    let newBag = 
-                        x.Bag
-                        |> Array.filter((<>) item)
-                        |> Array.append 
-                            [| 
-                                { item with Quantity = item.Quantity + ii.Quantity }
-                             |]
-                        |> makeBagItemsDistinct
-
-                    let inventory = { x with Bag = newBag }
-                    { inventory with Weight = inventory.Weight + item.ItemWeight }
-                | None -> 
-                    let newBag = x.Bag |> Array.append [|ii|] |> makeBagItemsDistinct
-                    let inventory = { x with Bag = newBag }
-                    { inventory with Weight = inventory.Weight + ii.ItemWeight }
-
-        member x.addItems (iiArr: InventoryItem array) = 
-            let newBag = x.Bag |> Array.append iiArr |> makeBagItemsDistinct
-            let inventory = { x with Bag = newBag }
-
-            { inventory with Weight = inventory.Weight + 0.0<kg> }
-
-        member x.dropItem (ii:InventoryItem) = 
-            let newBag = x.Bag |> Array.filter( (<>) ii)
-            let inventory = { x with Bag = newBag }
-            { inventory with Weight = inventory.Weight - ii.ItemWeight }
-       
-    type Equipment = {
-        Hat : Hat 
-        Armor : Armor 
-        Legs  : Pants 
-        Hands : Gauntlets 
-        Ring  : Ring 
-        Weapon : Weaponry
-        Shield : Shield option
-    }
+            member x.dropItem (ii:InventoryItem) = 
+                let newBag = x.Bag |> Array.filter( (<>) ii)
+                let inventory = { x with Bag = newBag }
+                { inventory with Weight = inventory.Weight - ii.ItemWeight }
+        
+        type Equipment = {
+            Hat : Hat 
+            Armor : Armor 
+            Legs  : Pants 
+            Hands : Gauntlets 
+            Ring  : Ring 
+            Weapon : Weaponry
+            Shield : Shield option
+        }

--- a/A game of light and shadows/GLSCore/InventoryItems.fs
+++ b/A game of light and shadows/GLSCore/InventoryItems.fs
@@ -10,7 +10,7 @@
 
     //Max weight of the inventory bag
     [<Literal>] 
-    let MaxWeight = 100.00<kg>
+    let MaxWeight = 500.00<kg>
     
     type IEnergyPoint =
         abstract CurrentPoints : float 
@@ -90,225 +90,332 @@
         | FromTheInventory
 
     type ConsummableItem = 
-        | HealthPotion      
-        | HighHealthPotion  
-        | MegaHealthPotion  
-        | Elixir            
-        | HighElixir        
-        | MegaElixir        
-        | PhoenixFeather    
-        | MedicinalHerb     
+        | HealthPotion        of int
+        | HighHealthPotion    of int
+        | MegaHealthPotion    of int
+        | Elixir              of int
+        | HighElixir          of int
+        | MegaElixir          of int
+        | PhoenixFeather      of int
+        | MedicinalHerb       of int
         override x.ToString() = 
             match x with 
-            | HealthPotion      -> "Health Potion"
-            | HighHealthPotion  -> "High Health Potion"
-            | MegaHealthPotion  -> "Mega Health Potion"
-            | Elixir            -> "Elixir"
-            | HighElixir        -> "High Elixir"
-            | MegaElixir        -> "Mega Elixir"
-            | PhoenixFeather    -> "Phoenix Feather"
-            | MedicinalHerb     -> "Medicinal Herb"
+            | HealthPotion     _ -> "Health Potion"
+            | HighHealthPotion _ -> "High Health Potion"
+            | MegaHealthPotion _ -> "Mega Health Potion"
+            | Elixir           _ -> "Elixir"
+            | HighElixir       _ -> "High Elixir"
+            | MegaElixir       _ -> "Mega Elixir"
+            | PhoenixFeather   _ -> "Phoenix Feather"
+            | MedicinalHerb    _ -> "Medicinal Herb"
 
         member x.Weight = 
             match x with 
-            | HealthPotion       -> 0.02<kg>
-            | HighHealthPotion   -> 0.03<kg>
-            | MegaHealthPotion   -> 0.05<kg>
-            | Elixir             -> 0.02<kg>
-            | HighElixir         -> 0.03<kg>
-            | MegaElixir         -> 0.05<kg>
-            | PhoenixFeather     -> 0.05<kg>
-            | MedicinalHerb      -> 0.03<kg>
+            | HealthPotion       _-> 0.02<kg>
+            | HighHealthPotion   _-> 0.03<kg>
+            | MegaHealthPotion   _-> 0.05<kg>
+            | Elixir             _-> 0.02<kg>
+            | HighElixir         _-> 0.03<kg>
+            | MegaElixir         _-> 0.05<kg>
+            | PhoenixFeather     _-> 0.05<kg>
+            | MedicinalHerb      _-> 0.03<kg>
 
         member x.Price = 
             match x with 
-            | HealthPotion       -> 100<usd>
-            | HighHealthPotion   -> 150<usd>
-            | MegaHealthPotion   -> 225<usd>
-            | Elixir             -> 125<usd>
-            | HighElixir         -> 175<usd>
-            | MegaElixir         -> 275<usd>
-            | PhoenixFeather     -> 350<usd>
-            | MedicinalHerb      -> 50<usd>
+            | HealthPotion      _ -> 100<usd>
+            | HighHealthPotion  _ -> 150<usd>
+            | MegaHealthPotion  _ -> 225<usd>
+            | Elixir            _ -> 125<usd>
+            | HighElixir        _ -> 175<usd>
+            | MegaElixir        _ -> 275<usd>
+            | PhoenixFeather    _ -> 350<usd>
+            | MedicinalHerb     _ -> 50<usd>
 
         member x.ItemQuantity = 
             match x with 
-            | HealthPotion       ->     0
-            | HighHealthPotion   ->     0
-            | MegaHealthPotion   ->     0
-            | Elixir             ->     0
-            | HighElixir         ->     0
-            | MegaElixir         ->     0
-            | PhoenixFeather     ->     0
-            | MedicinalHerb      ->     0
+            | HealthPotion      q -> q
+            | HighHealthPotion  q -> q
+            | MegaHealthPotion  q -> q
+            | Elixir            q -> q
+            | HighElixir        q -> q
+            | MegaElixir        q -> q
+            | PhoenixFeather    q -> q
+            | MedicinalHerb     q -> q
 
         member x.ConsummeItem (characterStat: CharacterStats) = 
             match x with 
-            | HealthPotion       -> { characterStat with Health = (characterStat.Health :> IEnergyPoint).raisePoints 15 :?> LifePoint }
-            | HighHealthPotion   -> { characterStat with Health = (characterStat.Health :> IEnergyPoint).raisePoints 30 :?> LifePoint }
-            | MegaHealthPotion   -> { characterStat with Health = (characterStat.Health :> IEnergyPoint).raisePoints 50 :?> LifePoint }
-            | Elixir             -> { characterStat with Mana = (characterStat.Health :> IEnergyPoint).raisePoints 10 :?> ManaPoint }
-            | HighElixir         -> { characterStat with Mana = (characterStat.Health :> IEnergyPoint).raisePoints 20 :?> ManaPoint }
-            | MegaElixir         -> { characterStat with Mana = (characterStat.Health :> IEnergyPoint).raisePoints 30 :?> ManaPoint }
-            | PhoenixFeather     -> 
+            | HealthPotion      q -> { characterStat with Health = (characterStat.Health :> IEnergyPoint).raisePoints 15 :?> LifePoint }
+            | HighHealthPotion  q -> { characterStat with Health = (characterStat.Health :> IEnergyPoint).raisePoints 30 :?> LifePoint }
+            | MegaHealthPotion  q -> { characterStat with Health = (characterStat.Health :> IEnergyPoint).raisePoints 50 :?> LifePoint }
+            | Elixir            q -> { characterStat with Mana = (characterStat.Health :> IEnergyPoint).raisePoints 10 :?> ManaPoint }
+            | HighElixir        q -> { characterStat with Mana = (characterStat.Health :> IEnergyPoint).raisePoints 20 :?> ManaPoint }
+            | MegaElixir        q -> { characterStat with Mana = (characterStat.Health :> IEnergyPoint).raisePoints 30 :?> ManaPoint }
+            | PhoenixFeather    q -> 
                 if characterStat.Health.isCharacterDead() <> true then characterStat
                 else { characterStat with 
                         Health = (characterStat.Health :> IEnergyPoint).raisePoints ( Math.Round characterStat.Health.MaxLife * 0.50 |> int32) :?> LifePoint
                         Mana = (characterStat.Mana :> IEnergyPoint).raisePoints (Math.Round characterStat.Mana.MaxMana * 0.50 |> int32) :?> ManaPoint
                     }
 
-            | MedicinalHerb      ->  { characterStat with Health = (characterStat.Health :> IEnergyPoint).raisePoints 5 :?> LifePoint }
-            
-
-        member x.updateItemQuantity value provenance= 
-            let itemVariation = 
-                match provenance with 
-                | FromTheShop -> value 
-                | FromTheInventory -> value * -1
-
-            let qty = x.ItemQuantity + itemVariation
-            let qty=
-                match qty with 
-                | t when t > 99 -> 99
-                | t when t <0 -> 0
-                | _ -> qty
-            qty          
+            | MedicinalHerb     q ->  { characterStat with Health = (characterStat.Health :> IEnergyPoint).raisePoints 5 :?> LifePoint }
             
     type Dagger = 
-        | RustedDagger of   WeaponStat
-        | IronDagger   of   WeaponStat 
-        | SteelDagger  of   WeaponStat
+        | RustedDagger of   WeaponStat  * int
+        | IronDagger   of   WeaponStat  * int
+        | SteelDagger  of   WeaponStat  * int
     with   
         override x.ToString() = 
             match x with 
-            | RustedDagger _ -> "Rusted dagger"
-            | IronDagger   _ -> "Iron dagger"
-            | SteelDagger  _ -> "Steel dagger"
+            | RustedDagger (_,_) -> "Rusted dagger"
+            | IronDagger   (_,_) -> "Iron dagger"
+            | SteelDagger  (_,_) -> "Steel dagger"
 
         member x.WeaponRank =
             match x with 
-            | RustedDagger _ -> RankE
-            | IronDagger   _-> RankD
-            | SteelDagger  _-> RankC
+            | RustedDagger (_,_) -> RankE
+            | IronDagger   (_,_)-> RankD
+            | SteelDagger  (_,_)-> RankC
 
         member x.WeaponStats = 
             match x with
-            | RustedDagger s -> s 
-            | IronDagger   s -> s
-            | SteelDagger  s -> s 
+            | RustedDagger (s,_) -> s 
+            | IronDagger   (s,_) -> s
+            | SteelDagger  (s,_) -> s 
             
         member x.Weight = 
             match x with 
-            | RustedDagger _ -> 2.10<kg>
-            | IronDagger   _ -> 2.80<kg>
-            | SteelDagger  _ -> 5.25<kg>
+            | RustedDagger (_,_) -> 2.10<kg>
+            | IronDagger   (_,_) -> 2.80<kg>
+            | SteelDagger  (_,_) -> 5.25<kg>
             
         member x.Price = 
              match x with 
-             | RustedDagger _ -> 80<usd> 
-             | IronDagger   _ -> 200<usd> 
-             | SteelDagger  _ -> 350<usd> 
+             | RustedDagger (_,_) -> 80<usd> 
+             | IronDagger   (_,_) -> 200<usd> 
+             | SteelDagger  (_,_) -> 350<usd> 
 
         member x.Quantity = 
             match x with 
-            | RustedDagger _ -> 0
-            | IronDagger   _ -> 0 
-            | SteelDagger  _ -> 0 
-
-        member x.UpdateQuantity value variationProvenance = 
-            let itemVariation = 
-                match variationProvenance with 
-                | FromTheShop -> value 
-                | FromTheInventory -> value * -1
-
-            let qty = x.Quantity + itemVariation
-            let qty=
-                match qty with 
-                | t when t > 99 -> 99
-                | t when t <0 -> 0
-                | _ -> qty
-            qty   
+            | RustedDagger (_,q) -> q
+            | IronDagger   (_,q) -> q 
+            | SteelDagger  (_,q) -> q    
 
     type Sword = 
-        | BrokenSword of WeaponStat
-        | RustedSword of WeaponStat
-        | IronSword   of WeaponStat
-        | SteelSword  of WeaponStat
+        | BrokenSword of WeaponStat * int
+        | RustedSword of WeaponStat * int
+        | IronSword   of WeaponStat * int
+        | SteelSword  of WeaponStat * int
     with
         member x.WeaponRank =
             match x with 
-            | BrokenSword _ -> RankE
-            | RustedSword _ -> RankE
-            | IronSword   _ -> RankD
-            | SteelSword  _ -> RankC
+            | BrokenSword (_,_) -> RankE
+            | RustedSword (_,_) -> RankE
+            | IronSword   (_,_) -> RankD
+            | SteelSword  (_,_) -> RankC
 
         member x.WeaponStats = 
             match x with
-            | BrokenSword s -> s
-            | RustedSword s -> s
-            | IronSword   s -> s
-            | SteelSword  s -> s
+            | BrokenSword (s,_) -> s
+            | RustedSword (s,_) -> s
+            | IronSword   (s,_) -> s
+            | SteelSword  (s,_) -> s
             
         member x.Weight = 
             match x with 
-            | BrokenSword _ -> 7.20<kg>
-            | RustedSword _ -> 8.50<kg>
-            | IronSword   _ -> 12.35<kg>
-            | SteelSword  _ -> 15.00<kg>
+            | BrokenSword (_,_) -> 7.20<kg>
+            | RustedSword (_,_) -> 8.50<kg>
+            | IronSword   (_,_) -> 12.35<kg>
+            | SteelSword  (_,_) -> 15.00<kg>
 
         member x.Price = 
              match x with 
-             | BrokenSword _ -> 90<usd>
-             | RustedSword _ -> 120<usd>
-             | IronSword   _ -> 250<usd>
-             | SteelSword  _ -> 525<usd>
+             | BrokenSword (_,_) -> 90<usd>
+             | RustedSword (_,_) -> 120<usd>
+             | IronSword   (_,_) -> 250<usd>
+             | SteelSword  (_,_) -> 525<usd>
 
         member x.Quantity = 
             match x with 
-            | BrokenSword _ -> 0
-            | RustedSword _ -> 0
-            | IronSword   _ -> 0 
-            | SteelSword  _ -> 0
-
-        member x.UpdateQuantity value variationProvenance = 
-            let itemVariation = 
-                match variationProvenance with 
-                | FromTheShop -> value 
-                | FromTheInventory -> value * -1
-
-            let qty = x.Quantity + itemVariation
-            let qty=
-                match qty with 
-                | t when t > 99 -> 99
-                | t when t <0 -> 0
-                | _ -> qty
-            qty   
+            | BrokenSword (_,q) -> q
+            | RustedSword (_,q) -> q
+            | IronSword   (_,q) -> q 
+            | SteelSword  (_,q) -> q   
 
     type Axe = 
-        | RustedAxe of InventoryItem * WeaponStat
-        | IronAxe of InventoryItem * WeaponStat
-        | RustedBattleAxe of InventoryItem * WeaponStat
-        | IronBattleAxe of InventoryItem * WeaponStat
-        | StellBattleAxe of InventoryItem * WeaponStat
+        | RustedAxe         of WeaponStat  * int
+        | IronAxe           of WeaponStat  * int
+        | RustedBattleAxe   of WeaponStat  * int
+        | IronBattleAxe     of WeaponStat  * int
+        | StellBattleAxe    of WeaponStat  * int
+    with
+        member x.WeaponRank =
+            match x with 
+            | RustedAxe       (_,_) -> RankE
+            | IronAxe         (_,_) -> RankD
+            | RustedBattleAxe (_,_) -> RankE
+            | IronBattleAxe   (_,_) -> RankD
+            | StellBattleAxe  (_,_) -> RankC
+
+        member x.WeaponStats = 
+            match x with
+            | RustedAxe       (s,_) -> s
+            | IronAxe         (s,_) -> s
+            | RustedBattleAxe (s,_) -> s
+            | IronBattleAxe   (s,_) -> s
+            | StellBattleAxe  (s,_) -> s
+
+        member x.Weight = 
+            match x with 
+            | RustedAxe          (_,_) -> 8.00<kg>
+            | IronAxe            (_,_) -> 10.00<kg>
+            | RustedBattleAxe    (_,_) -> 9.00<kg>
+            | IronBattleAxe      (_,_) -> 13.00<kg>
+            | StellBattleAxe     (_,_) -> 16.00<kg>
+
+        member x.Price = 
+             match x with 
+             | RustedAxe          (_,_) ->  125<usd>
+             | IronAxe            (_,_) ->  280<usd>
+             | RustedBattleAxe    (_,_) ->  150<usd>
+             | IronBattleAxe      (_,_) ->  300<usd>
+             | StellBattleAxe     (_,_) ->  425<usd>
+
+        member x.Quantity = 
+            match x with 
+            | RustedAxe          (_,q) ->  q
+            | IronAxe            (_,q) ->  q
+            | RustedBattleAxe    (_,q) ->  q
+            | IronBattleAxe      (_,q) ->  q
+            | StellBattleAxe     (_,q) ->  q
 
     type Spear =
-        | RustedSpear of InventoryItem  * WeaponStat
-        | IronSpear  of InventoryItem * WeaponStat
-        | SteelSpear of InventoryItem * WeaponStat
+        | RustedSpear of WeaponStat * int
+        | IronSpear   of WeaponStat * int
+        | SteelSpear  of WeaponStat * int
+    with
+        member x.WeaponRank =
+            match x with 
+            | RustedSpear (_,_) -> RankE
+            | IronSpear   (_,_) -> RankD
+            | SteelSpear  (_,_) -> RankC
+            
+        member x.WeaponStats = 
+            match x with
+            | RustedSpear (s,_) -> s
+            | IronSpear   (s,_) -> s
+            | SteelSpear  (s,_) -> s
+                      
+        member x.Weight = 
+            match x with 
+            | RustedSpear (_,_) -> 15.0<kg>
+            | IronSpear   (_,_) -> 20.0<kg>
+            | SteelSpear  (_,_) -> 30.0<kg>
+
+        member x.Price = 
+             match x with 
+             | RustedSpear (_,_) -> 200<usd>
+             | IronSpear   (_,_) -> 325<usd>
+             | SteelSpear  (_,_) -> 550<usd>
+
+        member x.Quantity = 
+            match x with 
+            | RustedSpear (_,q) ->  q
+            | IronSpear   (_,q) ->  q
+            | SteelSpear  (_,q) ->  q             
 
     type Staff = 
-        | RookieStaff of InventoryItem * WeaponStat
-        | AdeptStaff  of InventoryItem * WeaponStat
-        | SorcererStaff of InventoryItem * WeaponStat
-        | NecromancerStaff of InventoryItem * WeaponStat
+        | RookieStaff       of WeaponStat * int 
+        | AdeptStaff        of WeaponStat * int 
+        | SorcererStaff     of WeaponStat * int 
+        | NecromancerStaff  of WeaponStat * int 
+    with
+        member x.WeaponRank =
+            match x with 
+            | RookieStaff      (_,_) -> RankE
+            | AdeptStaff       (_,_) -> RankD
+            | SorcererStaff    (_,_) -> RankB
+            | NecromancerStaff (_,_) -> RankA
+
+        member x.WeaponStats = 
+            match x with
+            | RookieStaff      (s,_) -> s
+            | AdeptStaff       (s,_) -> s
+            | SorcererStaff    (s,_) -> s
+            | NecromancerStaff (s,_) -> s
+            
+        member x.Weight = 
+            match x with 
+            | RookieStaff      (_,_) -> 2.20<kg>
+            | AdeptStaff       (_,_) -> 4.20<kg>
+            | SorcererStaff    (_,_) -> 5.10<kg>
+            | NecromancerStaff (_,_) -> 3.20<kg>
+
+        member x.Price = 
+             match x with 
+             | RookieStaff      (_,_) -> 180<usd>
+             | AdeptStaff       (_,_) -> 270<usd>
+             | SorcererStaff    (_,_) -> 445<usd>
+             | NecromancerStaff (_,_) -> 650<usd>
+
+        member x.Quantity = 
+            match x with 
+            | RookieStaff      (_,q)-> q
+            | AdeptStaff       (_,q)-> q
+            | SorcererStaff    (_,q)-> q 
+            | NecromancerStaff (_,q)-> q
 
     type Blade = 
-        | RustedLongBlade of InventoryItem * WeaponStat
-        | RustedKatana of InventoryItem * WeaponStat
-        | IronLongBlade of InventoryItem * WeaponStat
-        | CurvedLongBlade of InventoryItem * WeaponStat
-        | SteelKatana of InventoryItem * WeaponStat
-        | SteelLongBlade of InventoryItem * WeaponStat
+        | RustedLongBlade   of WeaponStat * int 
+        | RustedKatana      of WeaponStat * int 
+        | IronLongBlade     of WeaponStat * int 
+        | CurvedLongBlade   of WeaponStat * int 
+        | SteelKatana       of WeaponStat * int 
+        | SteelLongBlade    of WeaponStat * int 
+    with
+        member x.WeaponRank =
+            match x with 
+            | RustedLongBlade    (_,_) -> RankE
+            | RustedKatana       (_,_) -> RankE
+            | IronLongBlade      (_,_) -> RankD
+            | CurvedLongBlade    (_,_) -> RankD
+            | SteelKatana        (_,_) -> RankC
+            | SteelLongBlade     (_,_) -> RankC
+
+        member x.WeaponStats = 
+            match x with
+            | RustedLongBlade    (s,_) -> s
+            | RustedKatana       (s,_) -> s
+            | IronLongBlade      (s,_) -> s
+            | CurvedLongBlade    (s,_) -> s
+            | SteelKatana        (s,_) -> s
+            | SteelLongBlade     (s,_) -> s
+
+        member x.Weight = 
+            match x with 
+            | RustedLongBlade    (_,_) -> 6.00<kg>
+            | RustedKatana       (_,_) -> 7.75<kg>
+            | IronLongBlade      (_,_) -> 14.25<kg>
+            | CurvedLongBlade    (_,_) -> 11.20<kg>
+            | SteelKatana        (_,_) -> 16.78<kg>
+            | SteelLongBlade     (_,_) -> 15.30<kg>
+
+        member x.Price = 
+             match x with 
+             | RustedLongBlade    (_,_) ->  120<usd>
+             | RustedKatana       (_,_) ->  100<usd>
+             | IronLongBlade      (_,_) ->  215<usd>
+             | CurvedLongBlade    (_,_) ->  240<usd>
+             | SteelKatana        (_,_) ->  350<usd>
+             | SteelLongBlade     (_,_) ->  410<usd> 
+
+        member x.Quantity = 
+            match x with 
+            | RustedLongBlade    (_,q) ->  q
+            | RustedKatana       (_,q) ->  q
+            | IronLongBlade      (_,q) ->  q
+            | CurvedLongBlade    (_,q) ->  q
+            | SteelKatana        (_,q) ->  q
+            | SteelLongBlade     (_,q) ->  q
 
     type SpellbookStats = {
         AttackRange : int 
@@ -317,24 +424,118 @@
     }
 
     type Spellbook =
-        | Fireball of InventoryItem * SpellbookStats
-        | Thunder of InventoryItem * SpellbookStats
-        | Frost of InventoryItem * SpellbookStats
-        | Hellfire of InventoryItem * SpellbookStats
-        | BlackFire of InventoryItem * SpellbookStats
-        | Tornado of InventoryItem * SpellbookStats
-        | WildWind of InventoryItem * SpellbookStats
-        | StormOfBlades of InventoryItem * SpellbookStats
-        | ThorStorm of InventoryItem * SpellbookStats
-   
+        | Fireball      of SpellbookStats * int  
+        | Thunder       of SpellbookStats * int 
+        | Frost         of SpellbookStats * int 
+        | Hellfire      of SpellbookStats * int 
+        | BlackFire     of SpellbookStats * int 
+        | StormOfBlades of SpellbookStats * int 
+    with
+        member x.SpellRank =
+            match x with 
+            | Fireball        (_, _) -> RankE
+            | Thunder         (_, _) -> RankE
+            | Frost           (_, _) -> RankE
+            | Hellfire        (_, _) -> RankC
+            | BlackFire       (_, _) -> RankC
+            | StormOfBlades   (_, _) -> RankC
+
+
+        member x.SpellStats = 
+            match x with
+            | Fireball        (s, _) -> s
+            | Thunder         (s, _) -> s
+            | Frost           (s, _) -> s
+            | Hellfire        (s, _) -> s
+            | BlackFire       (s, _) -> s
+            | StormOfBlades   (s, _) -> s
+            
+        member x.Weight = 
+            match x with 
+            | Fireball        (_, _) -> 0.05<kg>
+            | Thunder         (_, _) -> 0.05<kg>
+            | Frost           (_, _) -> 0.05<kg>
+            | Hellfire        (_, _) -> 0.05<kg>
+            | BlackFire       (_, _) -> 0.05<kg>
+            | StormOfBlades   (_, _) -> 0.05<kg>
+
+        member x.Price = 
+             match x with 
+             | Fireball        (_, _) -> 150<usd>
+             | Thunder         (_, _) -> 150<usd>
+             | Frost           (_, _) -> 150<usd>
+             | Hellfire        (_, _) -> 350<usd>
+             | BlackFire       (_, _) -> 350<usd>
+             | StormOfBlades   (_, _) -> 350<usd>
+
+        member x.Quantity = 
+            match x with 
+            | Fireball        (_, q) -> q
+            | Thunder         (_, q) -> q
+            | Frost           (_, q) -> q
+            | Hellfire        (_, q) -> q
+            | BlackFire       (_, q) -> q
+            | StormOfBlades   (_, q) -> q
+
     type Weaponry = 
-        | Dagger of Dagger 
-        | Sword of Sword 
-        | Axe of Axe
-        | Spear of Spear
-        | Staff of Staff 
-        | LongBlade of Blade
-        | Spellbook of Spellbook
+        | Dagger        of Dagger 
+        | Sword         of Sword 
+        | Axe           of Axe
+        | Spear         of Spear
+        | Staff         of Staff 
+        | LongBlade     of Blade
+        | Spellbook     of Spellbook
+
+    with 
+        member x.Price = 
+            match x with 
+            | Dagger     w -> w.Price
+            | Sword      w -> w.Price
+            | Axe        w -> w.Price
+            | Spear      w -> w.Price
+            | Staff      w -> w.Price
+            | LongBlade  w -> w.Price
+            | Spellbook  w -> w.Price
+
+        member x.Quantity =
+            match x with
+            | Dagger     w -> w.Quantity
+            | Sword      w -> w.Quantity
+            | Axe        w -> w.Quantity
+            | Spear      w -> w.Quantity
+            | Staff      w -> w.Quantity
+            | LongBlade  w -> w.Quantity
+            | Spellbook  w -> w.Quantity
+
+        member x.Weight =
+            match x with
+            | Dagger     w -> w.Weight
+            | Sword      w -> w.Weight
+            | Axe        w -> w.Weight
+            | Spear      w -> w.Weight
+            | Staff      w -> w.Weight
+            | LongBlade  w -> w.Weight
+            | Spellbook  w -> w.Weight
+
+        member x.Stats = 
+            match x with
+            | Dagger     w -> w.WeaponStats
+            | Sword      w -> w.WeaponStats
+            | Axe        w -> w.WeaponStats
+            | Spear      w -> w.WeaponStats
+            | Staff      w -> w.WeaponStats
+            | LongBlade  w -> w.WeaponStats
+            // Might have problems for spell books stats... atm
+
+        member x.Rank =
+            match x with 
+            | Dagger     w -> w.WeaponRank
+            | Sword      w -> w.WeaponRank
+            | Axe        w -> w.WeaponRank
+            | Spear      w -> w.WeaponRank
+            | Staff      w -> w.WeaponRank
+            | LongBlade  w -> w.WeaponRank
+            | Spellbook  w -> w.SpellRank
 
     type Hat = 
         | SorcererHat of InventoryItem 
@@ -377,25 +578,32 @@
         | HeavyShield of InventoryItem
         | SteelShield of InventoryItem
 
-    type CharacterWearable = 
+    type CharacterProtection = 
         | Shield        of Shield 
         | Ring          of Ring 
         | Gloves        of Gauntlets 
         | Legs          of Pants
         | Armor         of Armor 
         | Hat           of Hat 
-        | Weapon        of Weaponry
-        | Spells        of Spellbook
-        | LongBlade     of Blade 
-        | MagicStaff    of Staff
-        | LongSpear     of Spear 
-        | Axe           of Axe 
-        | Sword         of Sword
-        | Dagger        of Dagger 
 
     type GameItem = 
         | Consummable   of ConsummableItem
-        | Wearable      of CharacterWearable
+        | Weapon        of Weaponry
+        | Wearable      of CharacterProtection
+    with 
+        member x.UpdateQuantity value variationProvenance = 
+            let itemVariation = 
+                match variationProvenance with 
+                | FromTheShop -> value 
+                | FromTheInventory -> value * -1
+
+            let qty = x.Quantity + itemVariation
+            let qty=
+                match qty with 
+                | t when t > 99 -> 99
+                | t when t <0 -> 0
+                | _ -> qty
+            qty  
 
     let makeBagItemsDistinct (bag: GameItem array) = 
         bag |> Seq.distinct |> Seq.toArray

--- a/A game of light and shadows/GLSCore/InventoryItems.fs
+++ b/A game of light and shadows/GLSCore/InventoryItems.fs
@@ -29,10 +29,9 @@
         Rank : WeaponRank
     }
 
-    type InventoryItem =
-
-        abstract member Quantity : int with get, set
-
+    type ItemVariationProvenance = 
+        | FromTheShop
+        | FromTheInventory
 
     type ConsummableItem = 
         | HealthPotion      
@@ -43,9 +42,7 @@
         | MegaElixir        
         | PhoenixFeather    
         | MedicinalHerb     
-        | Antidote   
-    interface InventoryItem 
-    with 
+        | Antidote    
         override x.ToString() = 
             match x with 
             | HealthPotion      -> "Health Potion"
@@ -83,14 +80,85 @@
             | Antidote           -> 125<usd>
 
         member x.ItemQuantity = 
+            match x with 
+            | HealthPotion       ->     0
+            | HighHealthPotion   ->     0
+            | MegaHealthPotion   ->     0
+            | Elixir             ->     0
+            | HighElixir         ->     0
+            | MegaElixir         ->     0
+            | PhoenixFeather     ->     0
+            | MedicinalHerb      ->     0
+            | Antidote           ->     0
+
+        member x.updateItemQuantity value provenance= 
+            let itemVariation = 
+                match provenance with 
+                | FromTheShop -> value 
+                | FromTheInventory -> value * -1
+
+            let qty = x.ItemQuantity + itemVariation
+            let qty=
+                match qty with 
+                | t when t > 99 -> 99
+                | t when t <0 -> 0
+                | _ -> qty
+            qty          
             
-
-
-
     type Dagger = 
-        | RustedDagger of InventoryItem * WeaponStat
-        | IronDagger of InventoryItem  * WeaponStat 
-        | SteelDagger of InventoryItem * WeaponStat
+        | RustedDagger of   WeaponStat
+        | IronDagger   of   WeaponStat 
+        | SteelDagger  of   WeaponStat
+    with   
+        override x.ToString() = 
+            match x with 
+            | RustedDagger _ -> "Rusted dagger"
+            | IronDagger   _ -> "Iron dagger"
+            | SteelDagger  _ -> "Steel dagger"
+
+        member x.WeaponRank =
+            match x with 
+            | RustedDagger _ -> RankE
+            | IronDagger   _-> RankD
+            | SteelDagger  _-> RankC
+
+        member x.WeaponStats = 
+            match x with
+            | RustedDagger s -> s 
+            | IronDagger   s -> s
+            | SteelDagger  s -> s 
+            
+        member x.Weight = 
+            match x with 
+            | RustedDagger _ -> 2.10<kg>
+            | IronDagger   _ -> 2.80<kg>
+            | SteelDagger  _ -> 5.25<kg>
+            
+        member x.Price = 
+             match x with 
+             | RustedDagger _ -> 80<usd> 
+             | IronDagger   _ -> 200<usd> 
+             | SteelDagger  _ -> 350<usd> 
+
+        member x.Quantity = 
+            match x with 
+            | RustedDagger _ -> 0
+            | IronDagger   _ -> 0 
+            | SteelDagger  _ -> 0 
+
+        member x.UpdateQuantity value variationProvenance = 
+            let itemVariation = 
+                match variationProvenance with 
+                | FromTheShop -> value 
+                | FromTheInventory -> value * -1
+
+            let qty = x.Quantity + itemVariation
+            let qty=
+                match qty with 
+                | t when t > 99 -> 99
+                | t when t <0 -> 0
+                | _ -> qty
+            qty   
 
     type Sword = 
         | BrokenSword of InventoryItem * WeaponStat
@@ -194,8 +262,7 @@
     let makeBagItemsDistinct (bag: InventoryItem array) = 
         bag |> Seq.distinct |> Seq.toArray
 
-    type GameItems = 
-        | Consummable   of ConsummableItem
+    type CharacterWearables = 
         | Shield        of Shield 
         | Ring          of Ring 
         | Gloves        of Gauntlets 
@@ -210,20 +277,12 @@
         | Axe           of Axe 
         | Sword         of Sword
         | Dagger        of Dagger 
+
+
+    type GameItems = 
+        | Consummable   of ConsummableItem
+        | Wearable      of CharacterWearable
     with 
-
-    (*
-        abstract member ItemName : string 
-
-        abstract member ItemDescription : string 
-
-        abstract member ItemWeight : float<kg> 
-
-        abstract member ItemPrice : float<usd> 
-
-        abstract member Quantity : int with get, set
-
-    *)
         member x.Name 
 
     type Inventory = {

--- a/A game of light and shadows/GLSCore/InventoryManager.fs
+++ b/A game of light and shadows/GLSCore/InventoryManager.fs
@@ -1,2 +1,47 @@
 ﻿module GLSManager.InventoryManager
 
+open System
+
+open GLSCore.GLSCore.InventoryItems
+open GLSManager.Protocol
+
+open Akka
+open Akka.FSharp
+
+
+let system = System.create "system" <| Configuration.load ()
+
+type InventorySystemState = {
+    Inventory : Inventory
+    GameManager : Actor<GameManagerProtocol>
+}
+
+let inventorySystemProcess
+    (mailbox: Actor<InventorySystemManagerProtocol>) =
+    let rec loop (state: InventorySystemState) = actor {
+        let! message = mailbox.Receive ()
+        match message with
+        | AddSingleItem item ->
+          let inventory = state.Inventory.addItem item
+          let state = { state with Inventory = inventory }
+          state.GameManager <<- BroadcastInventoryUpdate(inventory)
+          return! loop state
+        | AddItems items ->
+          let inventory = state.Inventory.addItems items
+          let state = { state with Inventory = inventory }
+          state.GameManager <<- BroadcastInventoryUpdate(inventory)
+          return! loop state
+        | RemoveSingleItem item ->
+          let inventory = state.Inventory.dropItem item
+          let state = { state with Inventory = inventory }
+          state.GameManager <<- BroadcastInventoryUpdate(inventory)
+          return! loop state
+       | MoveExcessToInventory ->
+          let inventory = state.Inventory.removeItemFromExcess()
+          let state = { state with Inventory = inventory }
+          state.GameManager <<- BroadcastInventoryUpdate(inventory)
+          return! loop state
+    }
+    loop ()
+
+let commandManagerRef = spawn system "Inventory System" <| inventorySystemProcess 

--- a/A game of light and shadows/GLSCore/PartyCharacter.fs
+++ b/A game of light and shadows/GLSCore/PartyCharacter.fs
@@ -16,6 +16,7 @@ type PartyCharacter(job: CharacterJob,
                     equipment: CharacterEquipement,
                     style: CombatStyle, 
                     id: int,
+                    ap: int,
                     oTiers: UnitTiers option,
                     state: CharacterState,
                     direction: PlayerDirection,
@@ -41,5 +42,9 @@ type PartyCharacter(job: CharacterJob,
     override x.CharacterID = id
 
     override x.Tiers = oTiers
+
+    override x.ExperiencePoints = 0.00
+
+    override x.LevelUpPoints = 0
 
         

--- a/A game of light and shadows/GLSCore/Protocol.fs
+++ b/A game of light and shadows/GLSCore/Protocol.fs
@@ -7,67 +7,74 @@ open GLSCore.GameElement
 open GLSCore.CharacterAction
 open GLSCore.PartyCharacter
 
-type GlobalStateProtocol = 
-    | UpdateStoryline       of Storyline 
-    | UpdateBoard           of GameBoard 
+type GlobalStateProtocol =
+    | UpdateStoryline       of Storyline
+    | UpdateBoard           of GameBoard
     | UpdateMenu            of MenuState
     | UpdateBattleSequence  of BattleSequenceState
     | UpdateWeaponStore     of WeaponStoreState
     | UpdateItemStore       of ItemStoreState
 
 
-type GameManagerProtocol =  
-    | UpdateGlobalState 
+type GameManagerProtocol =
+    | UpdateGlobalState
     | DestroyCharacter of PartyCharacter
     | UpdateCharacterHealth of PartyCharacter
     | UpdateCharacterPosition of PartyCharacter
-    | UpdateCharacterDirection 
+    | UpdateCharacterDirection
+    | BroadcastInventoryUpdate of Inventory
     | StopManager
 
-// Define CharacterObserver which will update the BattleSequenceManager once a character performed an action. 
+// Define CharacterObserver which will update the BattleSequenceManager once a character performed an action.
 
-type BattleSequenceManagerProtocol = 
+type BattleSequenceManagerProtocol =
     | ChangePhase of BattlePhase
     | StopManager
 
-type InventoryManagerProtocol = 
-    | LookAtInventory 
-    | ReorderInventory 
-    | TossItem 
-    | AddItem 
-    | SelectItem 
-    | StopManager 
+type InventoryManagerProtocol =
+    | LookAtInventory
+    | ReorderInventory
+    | TossItem
+    | AddItem
+    | SelectItem
+    | StopManager
 
-type BattleViewManagerProtocol = 
-    | TryEvade 
-    | UseMeleeAttack 
-    | UseCharacterSpecialMove 
+type BattleViewManagerProtocol =
+    | TryEvade
+    | UseMeleeAttack
+    | UseCharacterSpecialMove
     | ApplyTemporaryDefenseUpgrade
-    | StopManager 
+    | StopManager
 
-type StoreManagerProtocol = 
-    | ShowStock 
-    | BuyItem 
-    | SellItem 
-    | StopManager 
+type StoreManagerProtocol =
+    | ShowStock
+    | BuyItem
+    | SellItem
+    | StopManager
 
-type WorldMapManagerProtocol = 
-    | RenderStoryPoint 
-    | MoveCharacterToStoryPoint 
+type WorldMapManagerProtocol =
+    | RenderStoryPoint
+    | MoveCharacterToStoryPoint
     | Stop
 
-type CommandManagerProtocol = 
-    | PerformAttackCommandOn 
-    | PerformMoveCommandWith 
-    | PerformDefendCommandWith 
-    | PerformRotateCommandWith 
+type CommandManagerProtocol =
+    | PerformAttackCommandOn
+    | PerformMoveCommandWith
+    | PerformDefendCommandWith
+    | PerformRotateCommandWith
     | PerformEndTurn
 
-type StateServerProtocol =  
-    | UpdateTeamPartyState 
-    | UpdatePartyCharacter 
+type StateServerProtocol =
+    | UpdateTeamPartyState
+    | UpdatePartyCharacter
     | UpdateGameBoardState
     | UpdateTeamPartyInventory
 
-type ExperienceSystemProtocol = 
+type InventorySystemManagerProtocol =
+  | AddSingleItem of GameItem
+  | AddItems of GameItem array
+  | RemoveSingleItem of GameItem
+  | MoveExcessToInventory
+
+type ExperienceSystemProtocol =
     | ComputeGain of PartyCharacter * PartyCharacter * EngageAction


### PR DESCRIPTION
The inventory system allows the the team's party to access game items that can be equipped during battle. 
Those items include consummables such medicinal herb to restore health points or phoenix feathers that can brought back the dead with 50% of health and mana. 
The inventory system will also keep in check the equipment usage and the weapons hit limits and once the usage gets to 0% and the hit limit gets to 0, then either the equipment or the weapon will disappear both from the inventory and the equipment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameoflightandshadows/a-game-of-light-and-shadows/101)
<!-- Reviewable:end -->
